### PR TITLE
Retrieve task id as a long and not an integer

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/TasksView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/TasksView.java
@@ -107,7 +107,7 @@ public class TasksView implements TasksUpdatedListener, RemoteHintListener {
         private Task task = null;
 
         public TaskRecord(Task t) {
-            setAttribute(ID_ATTR, t.getId().intValue());
+            setAttribute(ID_ATTR, t.getId().longValue());
             this.task = t;
             update(t);
         }


### PR DESCRIPTION
Related with #1993.