### PR TITLE
displayMaxNumberOfNodes

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMModel.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMModel.java
@@ -58,6 +58,11 @@ public abstract class RMModel implements Model {
     public abstract Map<String, NodeSource> getNodes();
 
     /**
+     * @return current limit of alive nodes.
+     */
+    public abstract long getMaxNumberOfNodes();
+
+    /**
      * @return node currently selected among all views, or null
      */
     public abstract Node getSelectedNode();

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMModelImpl.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMModelImpl.java
@@ -97,6 +97,8 @@ public class RMModelImpl extends RMModel implements RMEventDispatcher {
     private int numPhysicalHosts = 0;
     private int numVirtualHosts = 0;
 
+    private long maxNumberOfNodes = -1;
+
     RMModelImpl() {
         super();
 
@@ -395,6 +397,15 @@ public class RMModelImpl extends RMModel implements RMEventDispatcher {
 
     void setNumLost(int numLost) {
         this.numLost = numLost;
+    }
+
+    @Override
+    public long getMaxNumberOfNodes() {
+        return maxNumberOfNodes;
+    }
+
+    public void setMaxNumberOfNodes(long maxNumberOfNodes) {
+        this.maxNumberOfNodes = maxNumberOfNodes;
     }
 
     void setNumConfiguring(int numConfiguring) {

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/StatisticsView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/StatisticsView.java
@@ -117,7 +117,7 @@ public class StatisticsView implements NodesListener {
 
     public void nodesUpdated(Map<String, NodeSource> nodes) {
 
-        ListGridRecord[] r = new ListGridRecord[11];
+        ListGridRecord[] r = new ListGridRecord[12];
 
         ListGridRecord r1 = new ListGridRecord();
         r1.setAttribute("status", "Deploying");
@@ -181,21 +181,34 @@ public class StatisticsView implements NodesListener {
         r9.setAttribute("count", controller.getModel().getNumNodes());
         r[8] = r9;
 
+        ListGridRecord aliveLimit = new ListGridRecord();
+        if (isAliveNodesLimited()) {
+            aliveLimit.setAttribute("status", "Alive nodes limit");
+        } else {
+            aliveLimit.setAttribute("status", "Alive nodes unlimited");
+        }
+        aliveLimit.setAttribute("type", "Node");
+        aliveLimit.setAttribute("count", controller.getModel().getMaxNumberOfNodes());
+        r[9] = aliveLimit;
+
         ListGridRecord r10 = new ListGridRecord();
         r10.setAttribute("status", "Physical");
         r10.setAttribute("type", "Host");
         r10.setAttribute("icon", RMImages.instance.host_16().getSafeUri().asString());
         r10.setAttribute("count", controller.getModel().getNumPhysicalHosts());
-        r[9] = r10;
+        r[10] = r10;
 
         ListGridRecord r11 = new ListGridRecord();
         r11.setAttribute("status", "Virtual");
         r11.setAttribute("type", "Host");
         r11.setAttribute("icon", RMImages.instance.host_virtual_16().getSafeUri().asString());
         r11.setAttribute("count", controller.getModel().getNumVirtualHosts());
-        r[10] = r11;
+        r[11] = r11;
 
         this.grid.setData(r);
     }
 
+    private boolean isAliveNodesLimited() {
+        return controller.getModel().getMaxNumberOfNodes() > -1;
+    }
 }


### PR DESCRIPTION
Add Alive nodes limit row

A alive node limit row is added. It shows the corresponding maxNumberOfNodes. If the alive nodes are not limited, the description is changed to alive nodes unlimited and the corresponding maxNumberOfNodes is displayed next to it, which is a negative number.