### PR TITLE
Fix catalog url

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -88,8 +88,7 @@ public class SubmitWindow {
 
     private static final String CATALOG_SELECT_BUCKET = "Select a Bucket";
     private static final String CATALOG_SELECT_WF = "Select a Workflow";
-    private static final String URL_CATALOG = GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
-    private static final String URL_CATALOG_BUCKETS = URL_CATALOG + "/buckets";
+    private static final String URL_CATALOG_BUCKETS = "/buckets";
     private static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZ";
     private static final String URL_SUBMIT_XML = GWT.getModuleBaseURL() + "submitedit";
     private static final String URL_UPLOAD_FILE = GWT.getModuleBaseURL() + "uploader";
@@ -173,6 +172,21 @@ public class SubmitWindow {
      */
     public void destroy() {
         this.window.destroy();
+    }
+
+    /**
+     * @return the configured Catalog url, if none has been specified, the default one is used instead
+     */
+    private String getCatalogUrl() {
+        String catalogUrl = SchedulerConfig.get().getCatalogUrl();
+        if ("".compareTo(catalogUrl) == 0) {
+            catalogUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
+            GWT.log("Pas d'url configurée pour le Catalog, on va utiliser celle normalement disponible dans le web container");
+        }
+        else {
+            GWT.log("On utilise l'url configurée pour le Catalog");
+        }
+        return catalogUrl;
     }
 
     private void initRootPage() {
@@ -448,7 +462,8 @@ public class SubmitWindow {
             public void onChange(ChangeEvent event) {
                 String selectedBucket = bucketsListBox.getSelectedValue();
                 if (CATALOG_SELECT_BUCKET.compareTo(selectedBucket) != 0) {
-                    String workflowUrl = URL_CATALOG_BUCKETS + "/" + catalogBucketsMap.get(selectedBucket) + "/workflows";
+                    String workflowUrl = getCatalogUrl() + URL_CATALOG_BUCKETS + "/" +
+                            catalogBucketsMap.get(selectedBucket) + "/workflows";
                     RequestBuilder req = new RequestBuilder(RequestBuilder.GET, workflowUrl);
                     req.setCallback(new RequestCallback() {
                         @Override
@@ -489,7 +504,7 @@ public class SubmitWindow {
         });
 
 
-        RequestBuilder req = new RequestBuilder(RequestBuilder.GET, URL_CATALOG + "/buckets");
+        RequestBuilder req = new RequestBuilder(RequestBuilder.GET, getCatalogUrl() + "/buckets");
         req.setCallback(new RequestCallback() {
             @Override
             public void onResponseReceived(Request request, Response response) {

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -179,14 +179,17 @@ public class SubmitWindow {
      */
     private String getCatalogUrl() {
         String catalogUrl = SchedulerConfig.get().getCatalogUrl();
-        if ("".compareTo(catalogUrl) == 0) {
-            catalogUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
-            GWT.log("Pas d'url configurée pour le Catalog, on va utiliser celle normalement disponible dans le web container");
+        if (catalogUrl == null) {
+            catalogUrl = buildCatalogUrl();
         }
-        else {
-            GWT.log("On utilise l'url configurée pour le Catalog");
+        else if (catalogUrl.isEmpty()) {
+            catalogUrl = buildCatalogUrl();
         }
         return catalogUrl;
+    }
+
+    private String buildCatalogUrl() {
+        return GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
     }
 
     private void initRootPage() {
@@ -461,7 +464,7 @@ public class SubmitWindow {
             @Override
             public void onChange(ChangeEvent event) {
                 String selectedBucket = bucketsListBox.getSelectedValue();
-                if (CATALOG_SELECT_BUCKET.compareTo(selectedBucket) != 0) {
+                if (CATALOG_SELECT_BUCKET.equals(selectedBucket)) {
                     String workflowUrl = getCatalogUrl() + URL_CATALOG_BUCKETS + "/" +
                             catalogBucketsMap.get(selectedBucket) + "/workflows";
                     RequestBuilder req = new RequestBuilder(RequestBuilder.GET, workflowUrl);

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -76,6 +76,7 @@ import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.layout.HLayout;
 import com.smartgwt.client.widgets.layout.Layout;
 import com.smartgwt.client.widgets.layout.VLayout;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
 
 /**
@@ -87,7 +88,7 @@ public class SubmitWindow {
 
     private static final String CATALOG_SELECT_BUCKET = "Select a Bucket";
     private static final String CATALOG_SELECT_WF = "Select a Workflow";
-    private static final String URL_CATALOG = GWT.getHostPageBaseURL() + "workflow-catalog";
+    private static final String URL_CATALOG = GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
     private static final String URL_CATALOG_BUCKETS = URL_CATALOG + "/buckets";
     private static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZ";
     private static final String URL_SUBMIT_XML = GWT.getModuleBaseURL() + "submitedit";

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -88,15 +88,14 @@ public class SubmitWindow {
 
     private static final String CATALOG_SELECT_BUCKET = "Select a Bucket";
     private static final String CATALOG_SELECT_WF = "Select a Workflow";
-    private static final String URL_CATALOG_BUCKETS = "/buckets";
     private static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZ";
     private static final String URL_SUBMIT_XML = GWT.getModuleBaseURL() + "submitedit";
     private static final String URL_UPLOAD_FILE = GWT.getModuleBaseURL() + "uploader";
-
     private static final String METHOD_INSTRUCTION = "Select a method";
     private static final String METHOD_FROM_FILE = "import from file";
     private static final String METHOD_FROM_CATALOG = "import from Catalog";
-
+    private static final int width = 420;
+    private static final int height = 500;
 
     private Window window;
 
@@ -144,9 +143,8 @@ public class SubmitWindow {
     private HashMap<String, Integer> catalogBucketsMap;
     private HashMap<String, Integer> catalogWorkflowsMap;
 
+    private String CATALOG_URL = null;
 
-    private static final int width = 420;
-    private static final int height = 500;
 
     /**
      * Default constructor
@@ -175,21 +173,21 @@ public class SubmitWindow {
     }
 
     /**
-     * @return the configured Catalog url, if none has been specified, the default one is used instead
+     * Builds the catalog URL. If none is configured in the settings file, sets the URL to the bundled Catalog
+     *
      */
-    private String getCatalogUrl() {
-        String catalogUrl = SchedulerConfig.get().getCatalogUrl();
-        if (catalogUrl == null) {
-            catalogUrl = buildCatalogUrl();
+    private void buildCatalogUrl() {
+        String catalogUrlFromConfig = SchedulerConfig.get().getCatalogUrl();
+        String defaultCatalogUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
+        if (catalogUrlFromConfig == null) {
+            CATALOG_URL = defaultCatalogUrl;
         }
-        else if (catalogUrl.isEmpty()) {
-            catalogUrl = buildCatalogUrl();
+        else if (catalogUrlFromConfig.isEmpty()) {
+            CATALOG_URL = defaultCatalogUrl;
         }
-        return catalogUrl;
-    }
-
-    private String buildCatalogUrl() {
-        return GWT.getHostPageBaseURL().replace("/scheduler/", "/") + "workflow-catalog";
+        else {
+            CATALOG_URL = catalogUrlFromConfig;
+        }
     }
 
     private void initRootPage() {
@@ -464,8 +462,8 @@ public class SubmitWindow {
             @Override
             public void onChange(ChangeEvent event) {
                 String selectedBucket = bucketsListBox.getSelectedValue();
-                if (CATALOG_SELECT_BUCKET.equals(selectedBucket)) {
-                    String workflowUrl = getCatalogUrl() + URL_CATALOG_BUCKETS + "/" +
+                if (!CATALOG_SELECT_BUCKET.equals(selectedBucket)) {
+                    String workflowUrl = CATALOG_URL + "/buckets/" +
                             catalogBucketsMap.get(selectedBucket) + "/workflows";
                     RequestBuilder req = new RequestBuilder(RequestBuilder.GET, workflowUrl);
                     req.setCallback(new RequestCallback() {
@@ -507,7 +505,7 @@ public class SubmitWindow {
         });
 
 
-        RequestBuilder req = new RequestBuilder(RequestBuilder.GET, getCatalogUrl() + "/buckets");
+        RequestBuilder req = new RequestBuilder(RequestBuilder.GET, CATALOG_URL + "/buckets");
         req.setCallback(new RequestCallback() {
             @Override
             public void onResponseReceived(Request request, Response response) {
@@ -772,6 +770,9 @@ public class SubmitWindow {
     }
 
     private void build() {
+
+        buildCatalogUrl();
+
         initRootPage(); // ------------ root page of the window
         initSelectWfPart(); // -------- Select workflow Panel
         initVarsPart(); // ------------ Fill workflow variables Panel

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -87,7 +87,7 @@ public class SubmitWindow {
 
     private static final String CATALOG_SELECT_BUCKET = "Select a Bucket";
     private static final String CATALOG_SELECT_WF = "Select a Workflow";
-    private static final String URL_CATALOG = "http://localhost:8080/workflow-catalog";
+    private static final String URL_CATALOG = GWT.getHostPageBaseURL() + "workflow-catalog";
     private static final String URL_CATALOG_BUCKETS = URL_CATALOG + "/buckets";
     private static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZ";
     private static final String URL_SUBMIT_XML = GWT.getModuleBaseURL() + "submitedit";

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -106,7 +106,7 @@ public class SchedulerConfig extends Config {
     public static final String MOTD_URL = "sched.motd.url";
     private static final String DEFAULT_MOTD_URL = "";
 
-    /**  **/
+    /** Workflow Catalog URL **/
     public static final String CATALOG_URL = "sched.catalog.url";
 
     private static SchedulerConfig instance = null;
@@ -263,5 +263,16 @@ public class SchedulerConfig extends Config {
      */
     public int getLivelogsRefreshTime() {
         return Integer.parseInt(properties.get(LIVELOGS_REFRESH_TIME));
+    }
+
+    /**
+     * @return the catalog url or an empty string if none has been defined
+     */
+    public String getCatalogUrl() {
+        String catalogUrl = properties.get(CATALOG_URL);
+        if (catalogUrl == null) {
+            catalogUrl = "";
+        }
+        return catalogUrl;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -266,13 +266,9 @@ public class SchedulerConfig extends Config {
     }
 
     /**
-     * @return the catalog url or an empty string if none has been defined
+     * @return the catalog url or null if none has been defined
      */
     public String getCatalogUrl() {
-        String catalogUrl = properties.get(CATALOG_URL);
-        if (catalogUrl == null) {
-            catalogUrl = "";
-        }
-        return catalogUrl;
+        return properties.get(CATALOG_URL);
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -36,6 +36,7 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.shared;
 
+import com.google.gwt.core.client.GWT;
 import org.ow2.proactive_grid_cloud_portal.common.shared.Config;
 
 
@@ -104,6 +105,9 @@ public class SchedulerConfig extends Config {
     /** message of the day service URL */
     public static final String MOTD_URL = "sched.motd.url";
     private static final String DEFAULT_MOTD_URL = "";
+
+    /**  **/
+    public static final String CATALOG_URL = "sched.catalog.url";
 
     private static SchedulerConfig instance = null;
 

--- a/scheduler-portal/src/main/webapp/scheduler.conf
+++ b/scheduler-portal/src/main/webapp/scheduler.conf
@@ -1,5 +1,8 @@
-# must be accessible remotly but given the public address our hostname of the scheduler
+# must be accessible remotely but given the public address our hostname of the scheduler
 sched.rest.url=http://localhost:8080/rest
+
+# must be accessible remotely with the public address or hostname of the workflow catalog
+#sched.catalog.url=https://trydev.activeeon.com/workflow-catalog
 
 # define whether hostname checking is performed or not when HTTPS
 # is used to communicate with the REST API


### PR DESCRIPTION
This should fix the problem to access the default catalog from the scheduler portal. Also the catalog url has been parameterized in the Scheduler.conf file as the `sched.catalog.url` parameter. If this parameter is not defined, the default catalog bundled within the release will be used instead. Using a Catalog on a different host than the scheduler will need ow2-proactive/workflow-catalog#16 to be merged.