### PR TITLE
Let portal handle result metadata

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/ResultController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/ResultController.java
@@ -28,7 +28,7 @@ public class ResultController {
     }
 
 
-    public void doDownload(DynamicForm form, String contentType) {
+    public void doDownload(DynamicForm form, String contentType, String target) {
         Task task = this.parentController.getSelectedTask();
         if(task != null){
             String taskId = task.getName();
@@ -37,7 +37,9 @@ public class ResultController {
             String jobId = Long.toString(task.getJobId());
             form.getField(ResultView.JOB_ID_FIELD_NAME).setValue(jobId);
 
-            form.getField(ResultView.MEDIA_FIELD_NAME).setValue(contentType);
+            form.getField(ResultView.DESTINATION_FIELD_NAME).setValue(contentType);
+
+            form.setTarget(target);
 
             form.submitForm();
         }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/ResultView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/ResultView.java
@@ -70,7 +70,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.TasksCentricMo
 public class ResultView implements TaskSelectedListener, JobOutputListener {
 
     public static final String TASK_ID_FIELD_NAME = "taskId";
-    public static final String MEDIA_FIELD_NAME = "media";
+    public static final String DESTINATION_FIELD_NAME = "destination";
     public static final String JOB_ID_FIELD_NAME = "jobId";
     public static final String SESSION_ID_FIELD_NAME = "sessionId";
 
@@ -88,8 +88,8 @@ public class ResultView implements TaskSelectedListener, JobOutputListener {
     protected Layout formPane = null;
     protected Label taskSelectedLabel = null;
     protected DynamicForm downloadForm;
-    protected IButton textDownload;
-    protected IButton binaryDownload;
+    protected IButton openInBrowser;
+    protected IButton saveAsFile;
 
     protected ResultController controller = null;
 
@@ -157,43 +157,42 @@ public class ResultView implements TaskSelectedListener, JobOutputListener {
         sess.setValue(LoginModel.getInstance().getSessionId());
 
         final HiddenItem job = new HiddenItem(JOB_ID_FIELD_NAME);
-        final HiddenItem media = new HiddenItem(MEDIA_FIELD_NAME);
+        final HiddenItem destination = new HiddenItem(DESTINATION_FIELD_NAME);
         final HiddenItem task = new HiddenItem(TASK_ID_FIELD_NAME);
 
         this.downloadForm = new DynamicForm();
         this.downloadForm.setWidth100();
         this.downloadForm.setMethod(FormMethod.POST);
-        this.downloadForm.setTarget("_blank");
-        this.downloadForm.setFields(sess, job, media, task);
+        this.downloadForm.setFields(sess, job, destination, task);
         this.downloadForm.setAction(GWT.getModuleBaseURL() + "downloader");
 
-        this.textDownload = new IButton("View as text");
-        this.textDownload.setLeft(20);
-        this.textDownload.setWidth(200);
-        textDownload.addClickHandler(new ClickHandler() {
+        this.openInBrowser = new IButton("Open in browser");
+        this.openInBrowser.setLeft(20);
+        this.openInBrowser.setWidth(200);
+        openInBrowser.addClickHandler(new ClickHandler() {
             public void onClick(ClickEvent event) {
-                controller.doDownload(downloadForm, "text/plain");
+                controller.doDownload(downloadForm, "browser", "_blank");
             }
         });
-        this.binaryDownload = new IButton("Save as binary file");
-        this.binaryDownload.setLeft(20);
-        this.binaryDownload.setWidth(200);
+        this.saveAsFile = new IButton("Save as file");
+        this.saveAsFile.setLeft(20);
+        this.saveAsFile.setWidth(200);
 
-        binaryDownload.addClickHandler(new ClickHandler() {
+        saveAsFile.addClickHandler(new ClickHandler() {
             public void onClick(ClickEvent event) {
-                controller.doDownload(downloadForm, "application/octet-stream");
+                controller.doDownload(downloadForm, "file", "_top");
             }
         });
         formPane = new VLayout();
         formPane.setMembersMargin(10);
         formPane.setWidth100();
-        formPane.setMembers(taskPreviewLabelTitle, this.taskSelectedLabel, this.downloadForm, textDownload, this.binaryDownload);
+        formPane.setMembers(taskPreviewLabelTitle, this.taskSelectedLabel, this.downloadForm, openInBrowser, this.saveAsFile);
     }
 
 
     protected void goToNoSelectedTaskState() {
-        this.textDownload.setDisabled(true);
-        this.binaryDownload.setDisabled(true);
+        this.openInBrowser.setDisabled(true);
+        this.saveAsFile.setDisabled(true);
         this.taskSelectedLabel.setContents(this.noTaskSelectedMessage);
     }
 
@@ -203,8 +202,8 @@ public class ResultView implements TaskSelectedListener, JobOutputListener {
         if (task == null) {
             this.goToNoSelectedTaskState();
         } else {
-            this.textDownload.setDisabled(false);
-            this.binaryDownload.setDisabled(false);
+            this.openInBrowser.setDisabled(false);
+            this.saveAsFile.setDisabled(false);
             String label = "Task " + task.getName() + " (id: " + Long.toString(
                     task.getId()) + ") from job " + task.getJobName() + " (id: " + Long.toString(
                     task.getJobId()) + ")";

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/DownloadTaskResultServlet.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/DownloadTaskResultServlet.java
@@ -37,6 +37,7 @@
 package org.ow2.proactive_grid_cloud_portal.scheduler.server;
 
 import org.codehaus.jettison.json.JSONObject;
+import org.ow2.proactive.web.WebProperties;
 import org.ow2.proactive_grid_cloud_portal.common.client.json.JSONUtils;
 import org.ow2.proactive_grid_cloud_portal.common.server.Service;
 import org.slf4j.Logger;
@@ -84,19 +85,19 @@ public class DownloadTaskResultServlet extends HttpServlet {
             String contentType;
             if (destination.equals("file")) {
                 contentType = "application/octet-stream";
-            } else if (json.has("contentType")) {
-                contentType = json.get("contentType").toString();
+            } else if (json.has(WebProperties.METADATA_CONTENT_TYPE)) {
+                contentType = json.get(WebProperties.METADATA_CONTENT_TYPE).toString();
             } else {
                 contentType = "text/plain";
             }
             response.setContentType(contentType);
 
             if (destination.equals("file")) {
-                if (json.has("fileName")) {
-                    response.setHeader("Content-disposition", "attachment; filename=" + json.get("fileName").toString());
-                } else if (json.has("fileExtension")) {
+                if (json.has(WebProperties.METADATA_FILE_NAME)) {
+                    response.setHeader("Content-disposition", "attachment; filename=" + json.get(WebProperties.METADATA_FILE_NAME).toString());
+                } else if (json.has(WebProperties.METADATA_FILE_EXTENSION)) {
                     response.setHeader("Content-disposition", "attachment; filename=job" + jobId + "_" + taskId +
-                            "_result" + json.get("fileExtension").toString());
+                            "_result" + json.get(WebProperties.METADATA_FILE_EXTENSION).toString());
                 } else {
                     response.setHeader("Content-disposition", "attachment; filename=job" + jobId + "_" + taskId +
                             "_result");

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/RestClient.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/RestClient.java
@@ -658,6 +658,22 @@ public interface RestClient {
                                            String taskId);
 
     /**
+     * Gets the result of a task.
+     * @param sessionId the session id of the user which is logged in
+     * @param jobId the id of the job to which the task belongs
+     * @param taskId the id of the task to which the result is asked
+     * @return the result of the task
+     */
+    @GET
+    @GZIP
+    @Path("jobs/{jobid}/tasks/{taskid}/result/metadata")
+    @Produces("application/json")
+    InputStream taskResultMetadata(@HeaderParam("sessionid")
+                                           String sessionId, @PathParam("jobid")
+                                           String jobId, @PathParam("taskid")
+                                           String taskId);
+
+    /**
      * Gets the serialized result of a task.
      *
      * @param sessionId the session id of the user which is logged in

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/SchedulerServiceImpl.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/SchedulerServiceImpl.java
@@ -217,7 +217,7 @@ public class SchedulerServiceImpl extends Service implements SchedulerService {
     /**
      * Getter of the result of a task.
      *
-     * @param sessionId the session id of the user which is looged in
+     * @param sessionId the session id of the user which is logged in
      * @param jobId     the id of the job the task belongs to
      * @param taskId    the id of the task
      * @return the result
@@ -252,6 +252,26 @@ public class SchedulerServiceImpl extends Service implements SchedulerService {
             rethrowRestServerException(e);
             return null;
         }
+    }
+
+    /**
+     * Getter of the result metadata of a task.
+     *
+     * @param sessionId the session id of the user which is looged in
+     * @param jobId     the id of the job the task belongs to
+     * @param taskId    the id of the task
+     * @return the result metadata
+     * @throws RestServerException
+     * @throws ServiceException
+     */
+    public String getTaskResultMetadata(final String sessionId, final String jobId, final String taskId)
+            throws RestServerException, ServiceException {
+        return executeFunctionReturnStreamAsString(new Function<RestClient, InputStream>() {
+            @Override
+            public InputStream apply(RestClient restClient) {
+                return restClient.taskResultMetadata(sessionId, jobId, taskId);
+            }
+        });
     }
 
     /*


### PR DESCRIPTION
Result metadata allows the portal to:
- Download the result with a specific file name or file extension.
- Open in the browser specific content-types such as image, pdf, etc.