### PR TITLE
Point documentation to dev when Snapshot version

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -365,7 +365,7 @@ public class RMPage implements LogListener {
             Images.instance.icon_manual().getSafeUri().asString());
         documentationMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             public void onClick(MenuItemClickEvent event) {
-                String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "latest"
+                String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "dev"
                         : Config.get().getVersion();
                 Window.open("http://doc.activeeon.com/" + docVersion, "", "");
             }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
@@ -365,7 +365,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
             Images.instance.icon_manual().getSafeUri().asString());
         documentationMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             public void onClick(MenuItemClickEvent event) {
-                String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "latest"
+                String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "dev"
                         : Config.get().getVersion();
                 Window.open("http://doc.activeeon.com/" + docVersion, "", "");
             }


### PR DESCRIPTION
Point documentation to dev when Snapshot version

Problem:
- Documentation links of the SNAPSHOT version were pointing to the doc.activeeon.com/latest

Solution:
- Point the documentation links to doc.activeeon.com/dev