### PR TITLE
Adding a cross on In-Error tasks

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
@@ -636,7 +636,6 @@ public class VisualizationViewImage implements VisualizationView {
                     break;
                 case PAUSED:
                 case IN_ERROR:
-                    ft.get(name).running++;
                     break;
                 case PENDING:
                     break;


### PR DESCRIPTION
The style of In-Error Tasks is defined in app/styles/studio-standalone.css, so no process is done in scheduling portal which simply displays this style.