### PR TITLE
Remove azure logo link

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -289,22 +289,16 @@ public class RMPage implements LogListener {
         logoPA.addMember(new Img(RMImagesUnbundled.PA_ICON, logoStripHeight, logoStripHeight));
         logoPA.addMember(resourcesLabel);
 
-        ToolStrip logoAzure = new ToolStrip();
-        logoAzure.setHeight(logoStripHeight);
-        logoAzure.setWidth("33%");
-        logoAzure.setBackgroundImage("");
-        logoAzure.setBackgroundColor(logoStripBackgroundColor);
-        logoAzure.setMargin(0);
-        logoAzure.setBorder(logoStripBorder);
-        logoAzure.setAlign(Alignment.CENTER);
+        ToolStrip additionalLogoCenter = new ToolStrip();
+        additionalLogoCenter.setHeight(logoStripHeight);
+        additionalLogoCenter.setWidth("33%");
+        additionalLogoCenter.setBackgroundImage("");
+        additionalLogoCenter.setBackgroundColor(logoStripBackgroundColor);
+        additionalLogoCenter.setMargin(0);
+        additionalLogoCenter.setBorder(logoStripBorder);
+        additionalLogoCenter.setAlign(Alignment.CENTER);
         Img logoAzureImg = new Img(RMImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
-        logoAzureImg.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-                Window.open("https://azure.microsoft.com/", "", "");
-            }
-        });
-        logoAzure.addMember(logoAzureImg);
+        additionalLogoCenter.addMember(logoAzureImg);
 
         ToolStrip logoAE = new ToolStrip();
         logoAE.setHeight(logoStripHeight);
@@ -332,7 +326,7 @@ public class RMPage implements LogListener {
         logoStrip.setBorder(logoStripBorder);
         logoStrip.setMargin(0);
         logoStrip.addMember(logoPA);
-        logoStrip.addMember(logoAzure);
+        logoStrip.addMember(additionalLogoCenter);
         logoStrip.addMember(logoAE);
 
         return logoStrip;

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
@@ -239,22 +239,16 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         logoPA.addMember(new Img(SchedulerImagesUnbundled.PA_ICON, logoStripHeight, logoStripHeight));
         logoPA.addMember(schedulerLabel);
 
-        ToolStrip logoAzure = new ToolStrip();
-        logoAzure.setHeight(logoStripHeight);
-        logoAzure.setWidth("33%");
-        logoAzure.setBackgroundImage("");
-        logoAzure.setBackgroundColor(logoStripBackgroundColor);
-        logoAzure.setMargin(0);
-        logoAzure.setBorder(logoStripBorder);
-        logoAzure.setAlign(Alignment.CENTER);
+        ToolStrip additionalLogoCenter = new ToolStrip();
+        additionalLogoCenter.setHeight(logoStripHeight);
+        additionalLogoCenter.setWidth("33%");
+        additionalLogoCenter.setBackgroundImage("");
+        additionalLogoCenter.setBackgroundColor(logoStripBackgroundColor);
+        additionalLogoCenter.setMargin(0);
+        additionalLogoCenter.setBorder(logoStripBorder);
+        additionalLogoCenter.setAlign(Alignment.CENTER);
         Img logoAzureImg = new Img(SchedulerImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
-        logoAzureImg.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-                Window.open("https://azure.microsoft.com/", "", "");
-            }
-        });
-        logoAzure.addMember(logoAzureImg);
+        additionalLogoCenter.addMember(logoAzureImg);
 
         ToolStrip logoAE = new ToolStrip();
         logoAE.setHeight(logoStripHeight);
@@ -282,7 +276,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         logoStrip.setBorder(logoStripBorder);
         logoStrip.setMargin(0);
         logoStrip.addMember(logoPA);
-        logoStrip.addMember(logoAzure);
+        logoStrip.addMember(additionalLogoCenter);
         logoStrip.addMember(logoAE);
 
         return logoStrip;


### PR DESCRIPTION
- Change the azure logo to a logo without link.
- Rename the azure logo to additionalLogoCenter, to emphasize it's purpose of being a placeholder for an additional logo, later on after compilation.