### PR TITLE
Adapt createNodeSource RM call to API change

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
@@ -347,7 +347,7 @@ public class NSCreationWindow {
             public void onClick(ClickEvent event) {
                 infraForm.setValue("infra", infraSelect.getValueAsString());
                 infraForm.setValue("nsName", nameItem.getValueAsString());
-                infraForm.setValue("nsName", nodesRecoverableItem.getValueAsBoolean().toString());
+                infraForm.setValue("nodesRecoverable", nodesRecoverableItem.getValueAsBoolean().toString());
                 infraForm.setValue("policy", policySelect.getValueAsString());
                 infraForm.setValue("sessionId", LoginModel.getInstance().getSessionId());
                 infraForm.setCanSubmit(true);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
@@ -50,6 +50,7 @@ import com.smartgwt.client.widgets.Window;
 import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
+import com.smartgwt.client.widgets.form.fields.CheckboxItem;
 import com.smartgwt.client.widgets.form.fields.FormItem;
 import com.smartgwt.client.widgets.form.fields.HiddenItem;
 import com.smartgwt.client.widgets.form.fields.PasswordItem;
@@ -321,7 +322,11 @@ public class NSCreationWindow {
 
         final TextItem nameItem = new TextItem("nsName", "Name");
         DynamicForm nameForm = new DynamicForm();
-        nameForm.setFields(nameItem);
+
+        CheckboxItem nodesRecoverableItem = new CheckboxItem("nodesRecoverable", "Nodes Recoverable");
+        nodesRecoverableItem.setValue(true);
+        nodesRecoverableItem.setTooltip("Defines whether the nodes of this node source can be recovered after a crash of the Resource Manager");
+        nameForm.setFields(nameItem, nodesRecoverableItem);
 
         HLayout buttons = new HLayout();
 
@@ -342,6 +347,7 @@ public class NSCreationWindow {
             public void onClick(ClickEvent event) {
                 infraForm.setValue("infra", infraSelect.getValueAsString());
                 infraForm.setValue("nsName", nameItem.getValueAsString());
+                infraForm.setValue("nsName", nodesRecoverableItem.getValueAsBoolean().toString());
                 infraForm.setValue("policy", policySelect.getValueAsString());
                 infraForm.setValue("sessionId", LoginModel.getInstance().getSessionId());
                 infraForm.setCanSubmit(true);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NSCreationWindow.java
@@ -139,11 +139,13 @@ public class NSCreationWindow {
                 policySelect.setWidth(300);
 
                 HiddenItem name = new HiddenItem("nsName");
+                HiddenItem nodesRecoverable = new HiddenItem("nodesRecoverable");
                 HiddenItem callback = new HiddenItem("nsCallback");
                 HiddenItem session = new HiddenItem("sessionId");
 
                 ArrayList<FormItem> tmpAll = new ArrayList<FormItem>();
                 tmpAll.add(name);
+                tmpAll.add(nodesRecoverable);
                 tmpAll.add(callback);
                 tmpAll.add(session);
                 tmpAll.add(infraSelect);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMService.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMService.java
@@ -104,16 +104,18 @@ public interface RMService extends RemoteService {
      * @param nodeSourceName name of the new NS
      * @param infrastructureType infrastructure manager full class name
      * @param infrastructureParameters IM String parameters, null value for files
-     * @param infrastructureFileParamaters file parameters
+     * @param infrastructureFileParameters file parameters
      * @param policyType policy full class name
      * @param policyParameters String parameters, null value for files
      * @param policyFileParameters file parameters
+     * @param nodesRecoverable whether nodes can be recovered after a crash
      * @throws RestServerException 
      * @throws ServiceException
      */
     String createNodeSource(String sessionId, String nodeSourceName, String infrastructureType,
             String[] infrastructureParameters, String[] infrastructureFileParameters, String policyType,
-            String[] policyParameters, String[] policyFileParameters) throws RestServerException, ServiceException;
+            String[] policyParameters, String[] policyFileParameters, String nodesRecoverable)
+            throws RestServerException, ServiceException;
 
     /**
      * lock a set of nodes

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMServiceAsync.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMServiceAsync.java
@@ -98,16 +98,18 @@ public interface RMServiceAsync {
      * @param nodeSourceName name of the new NS
      * @param infrastructureType infrastructure manager full class name
      * @param infrastructureParameters IM String parameters, null value for files
-     * @param infrastructureFileParamaters file parameters
+     * @param infrastructureFileParameters file parameters
      * @param policyType policy full class name
      * @param policyParameters String parameters, null value for files
      * @param policyFileParameters file parameters
+     * @param nodesRecoverable whether nodes can be recovered after a crash
      * @param callback
      * @throws ServiceException
      */
     void createNodeSource(String sessionId, String nodeSourceName, String infrastructureType,
             String[] infrastructureParameters, String[] infrastructureFileParameters, String policyType,
-            String[] policyParameters, String[] policyFileParameters, AsyncCallback<String> callback);
+            String[] policyParameters, String[] policyFileParameters, String nodesRecoverable,
+            AsyncCallback<String> callback);
 
     /**
      * Lock a set of nodes

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/NSCreationServlet.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/NSCreationServlet.java
@@ -72,6 +72,7 @@ public class NSCreationServlet extends HttpServlet {
         String sessionId = "";
         String callbackName = "";
         String nsName = "";
+        String nodesRecoverable = "";
         String infra = "";
         String policy = "";
 
@@ -102,6 +103,8 @@ public class NSCreationServlet extends HttpServlet {
                         callbackName = fi.getString();
                     } else if (fieldName.equals("nsName")) {
                         nsName = fi.getString();
+                    } else if (fieldName.equals("nodesRecoverable")) {
+                        nodesRecoverable = fi.getString();
                     } else if (fieldName.equals("infra")) {
                         infra = fi.getString();
                         readingInfraParams = true;
@@ -148,7 +151,8 @@ public class NSCreationServlet extends HttpServlet {
                                                                                        toArray(infraFileParams),
                                                                                        policy,
                                                                                        toArray(policyParams),
-                                                                                       toArray(policyFileParams));
+                                                                                       toArray(policyFileParams),
+                                                                                       nodesRecoverable);
             JSONObject json = new JSONObject(jsonResult);
             if (json != null) {
                 if (json.has("result")) {

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
@@ -82,6 +82,8 @@ public class RMServiceImpl extends Service implements RMService {
      */
     private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 8;
 
+    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES = "true";
+
     /**
      * Thread pool shared by RestEasy client proxies.
      */
@@ -293,7 +295,8 @@ public class RMServiceImpl extends Service implements RMService {
                                                    infrastructureFileParameters,
                                                    policyType,
                                                    policyParameters,
-                                                   policyFileParameters);
+                                                   policyFileParameters,
+                                                   CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES);
             }
         });
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
@@ -82,8 +82,6 @@ public class RMServiceImpl extends Service implements RMService {
      */
     private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 8;
 
-    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES = "true";
-
     /**
      * Thread pool shared by RestEasy client proxies.
      */
@@ -283,7 +281,6 @@ public class RMServiceImpl extends Service implements RMService {
      */
     public String createNodeSource(final String sessionId, final String nodeSourceName, final String infrastructureType,
             final String[] infrastructureParameters, final String[] infrastructureFileParameters,
-<<<<<<< HEAD
             final String policyType, final String[] policyParameters, final String[] policyFileParameters,
             final String nodesRecoverable) throws RestServerException, ServiceException {
         return executeFunctionReturnStreamAsString(restClient -> restClient.createnodeSource(sessionId,
@@ -295,24 +292,6 @@ public class RMServiceImpl extends Service implements RMService {
                                                                                              policyParameters,
                                                                                              policyFileParameters,
                                                                                              nodesRecoverable));
-=======
-            final String policyType, final String[] policyParameters, final String[] policyFileParameters)
-            throws RestServerException, ServiceException {
-        return executeFunctionReturnStreamAsString(new Function<RestClient, InputStream>() {
-            @Override
-            public InputStream apply(RestClient restClient) {
-                return restClient.createnodeSource(sessionId,
-                                                   nodeSourceName,
-                                                   infrastructureType,
-                                                   infrastructureParameters,
-                                                   infrastructureFileParameters,
-                                                   policyType,
-                                                   policyParameters,
-                                                   policyFileParameters,
-                                                   CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES);
-            }
-        });
->>>>>>> Adapt createNodeSource RM call to API change
     }
 
     /*

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
@@ -82,8 +82,6 @@ public class RMServiceImpl extends Service implements RMService {
      */
     private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 8;
 
-    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES = "true";
-
     /**
      * Thread pool shared by RestEasy client proxies.
      */
@@ -283,22 +281,17 @@ public class RMServiceImpl extends Service implements RMService {
      */
     public String createNodeSource(final String sessionId, final String nodeSourceName, final String infrastructureType,
             final String[] infrastructureParameters, final String[] infrastructureFileParameters,
-            final String policyType, final String[] policyParameters, final String[] policyFileParameters)
-            throws RestServerException, ServiceException {
-        return executeFunctionReturnStreamAsString(new Function<RestClient, InputStream>() {
-            @Override
-            public InputStream apply(RestClient restClient) {
-                return restClient.createnodeSource(sessionId,
-                                                   nodeSourceName,
-                                                   infrastructureType,
-                                                   infrastructureParameters,
-                                                   infrastructureFileParameters,
-                                                   policyType,
-                                                   policyParameters,
-                                                   policyFileParameters,
-                                                   CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES);
-            }
-        });
+            final String policyType, final String[] policyParameters, final String[] policyFileParameters,
+            final String nodesRecoverable) throws RestServerException, ServiceException {
+        return executeFunctionReturnStreamAsString(restClient -> restClient.createnodeSource(sessionId,
+                                                                                             nodeSourceName,
+                                                                                             infrastructureType,
+                                                                                             infrastructureParameters,
+                                                                                             infrastructureFileParameters,
+                                                                                             policyType,
+                                                                                             policyParameters,
+                                                                                             policyFileParameters,
+                                                                                             nodesRecoverable));
     }
 
     /*

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RMServiceImpl.java
@@ -82,6 +82,8 @@ public class RMServiceImpl extends Service implements RMService {
      */
     private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 8;
 
+    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES = "true";
+
     /**
      * Thread pool shared by RestEasy client proxies.
      */
@@ -281,6 +283,7 @@ public class RMServiceImpl extends Service implements RMService {
      */
     public String createNodeSource(final String sessionId, final String nodeSourceName, final String infrastructureType,
             final String[] infrastructureParameters, final String[] infrastructureFileParameters,
+<<<<<<< HEAD
             final String policyType, final String[] policyParameters, final String[] policyFileParameters,
             final String nodesRecoverable) throws RestServerException, ServiceException {
         return executeFunctionReturnStreamAsString(restClient -> restClient.createnodeSource(sessionId,
@@ -292,6 +295,24 @@ public class RMServiceImpl extends Service implements RMService {
                                                                                              policyParameters,
                                                                                              policyFileParameters,
                                                                                              nodesRecoverable));
+=======
+            final String policyType, final String[] policyParameters, final String[] policyFileParameters)
+            throws RestServerException, ServiceException {
+        return executeFunctionReturnStreamAsString(new Function<RestClient, InputStream>() {
+            @Override
+            public InputStream apply(RestClient restClient) {
+                return restClient.createnodeSource(sessionId,
+                                                   nodeSourceName,
+                                                   infrastructureType,
+                                                   infrastructureParameters,
+                                                   infrastructureFileParameters,
+                                                   policyType,
+                                                   policyParameters,
+                                                   policyFileParameters,
+                                                   CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES);
+            }
+        });
+>>>>>>> Adapt createNodeSource RM call to API change
     }
 
     /*

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RestClient.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RestClient.java
@@ -67,7 +67,7 @@ public interface RestClient {
     InputStream policies(@HeaderParam("sessionid") String sessionId);
 
     @POST
-    @Path("/rm/nodesource/create")
+    @Path("/rm/nodesource/create/recovery")
     @Produces("application/json")
     InputStream createnodeSource(@HeaderParam("sessionId") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RestClient.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/RestClient.java
@@ -75,7 +75,8 @@ public interface RestClient {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters);
+            @FormParam("policyFileParameters") String[] policyFileParameters,
+            @FormParam("nodesRecoverable") String nodesRecoverable);
 
     @POST
     @Path("/rm/node/lock")


### PR DESCRIPTION
- change the RestClient with one more parameter specifying if the nodes of the node source are recoverable.
- pass parameter true to mark the nodes of the node source as recoverable when created through the RM portal