### PR TITLE
Enable multiple selection in jobs and tasks grids

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-#Mon, 08 Jan 2018 14:24:16 +0100
-schedulingPortalVersion=7.35.0-SNAPSHOT
+#Fri, 19 Jan 2018 00:07:58 +0100
+schedulingPortalVersion=7.36.0-SNAPSHOT

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsModel.java
@@ -53,6 +53,11 @@ public class JobsModel {
     private Job selectedJob = null;
 
     /**
+     * The current jobs selected on the grid.
+     */
+    private ArrayList<Integer> selectedJobsIds = null;
+
+    /**
      * Listener for the updates of the jobs list.
      */
     private ArrayList<JobsUpdatedListener> jobsUpdatedListeners = null;
@@ -241,5 +246,13 @@ public class JobsModel {
      */
     public void addJobSelectedListener(JobSelectedListener listener) {
         this.jobSelectedListeners.add(listener);
+    }
+
+    public ArrayList<Integer> getSelectedJobsIds() {
+        return selectedJobsIds;
+    }
+
+    public void setSelectedJobsIds(ArrayList<Integer> selectedJobsIds) {
+        this.selectedJobsIds = selectedJobsIds;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsModel.java
@@ -27,6 +27,7 @@ package org.ow2.proactive_grid_cloud_portal.scheduler.client.model;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.Job;
@@ -55,7 +56,7 @@ public class JobsModel {
     /**
      * The current jobs selected on the grid.
      */
-    private ArrayList<Integer> selectedJobsIds = null;
+    private List<Integer> selectedJobsIds = null;
 
     /**
      * Listener for the updates of the jobs list.
@@ -248,11 +249,11 @@ public class JobsModel {
         this.jobSelectedListeners.add(listener);
     }
 
-    public ArrayList<Integer> getSelectedJobsIds() {
+    public List<Integer> getSelectedJobsIds() {
         return selectedJobsIds;
     }
 
-    public void setSelectedJobsIds(ArrayList<Integer> selectedJobsIds) {
+    public void setSelectedJobsIds(List<Integer> selectedJobsIds) {
         this.selectedJobsIds = selectedJobsIds;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
@@ -47,6 +47,8 @@ public class TasksModel {
 
     protected Task selectedTask;
 
+    protected ArrayList<String> selectedTasksIds = null;
+
     protected ArrayList<TaskSelectedListener> tasksSelectedListeners = null;
 
     protected ArrayList<TasksUpdatedListener> tasksUpdatedListeners = null;
@@ -213,5 +215,13 @@ public class TasksModel {
 
     public void setTasksNavigationModel(TasksNavigationModel tasksNavigationModel) {
         this.tasksNavigationModel = tasksNavigationModel;
+    }
+
+    public ArrayList<String> getSelectedTasksIds() {
+        return selectedTasksIds;
+    }
+
+    public void setSelectedTasksIds(ArrayList<String> selectedTasksIds) {
+        this.selectedTasksIds = selectedTasksIds;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
@@ -47,7 +47,7 @@ public class TasksModel {
 
     protected Task selectedTask;
 
-    protected ArrayList<String> selectedTasksIds = null;
+    protected List<String> selectedTasksIds = null;
 
     protected ArrayList<TaskSelectedListener> tasksSelectedListeners = null;
 
@@ -217,11 +217,11 @@ public class TasksModel {
         this.tasksNavigationModel = tasksNavigationModel;
     }
 
-    public ArrayList<String> getSelectedTasksIds() {
+    public List<String> getSelectedTasksIds() {
         return selectedTasksIds;
     }
 
-    public void setSelectedTasksIds(ArrayList<String> selectedTasksIds) {
+    public void setSelectedTasksIds(List<String> selectedTasksIds) {
         this.selectedTasksIds = selectedTasksIds;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/ItemsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/ItemsListGrid.java
@@ -42,12 +42,7 @@ import com.smartgwt.client.data.fields.DataSourceIntegerField;
 import com.smartgwt.client.data.fields.DataSourceTextField;
 import com.smartgwt.client.widgets.grid.ListGrid;
 import com.smartgwt.client.widgets.grid.ListGridField;
-import com.smartgwt.client.widgets.grid.events.CellContextClickEvent;
-import com.smartgwt.client.widgets.grid.events.CellContextClickHandler;
-import com.smartgwt.client.widgets.grid.events.CellOutEvent;
-import com.smartgwt.client.widgets.grid.events.CellOutHandler;
-import com.smartgwt.client.widgets.grid.events.SelectionChangedHandler;
-import com.smartgwt.client.widgets.grid.events.SelectionEvent;
+import com.smartgwt.client.widgets.grid.events.*;
 import com.smartgwt.client.widgets.menu.Menu;
 
 
@@ -157,6 +152,12 @@ public abstract class ItemsListGrid<I> extends ListGrid {
                 selectionChangedHandler(event);
             }
         });
+
+        this.addSelectionUpdatedHandler(new SelectionUpdatedHandler() {
+            public void onSelectionUpdated(SelectionUpdatedEvent event) {
+                selectionUpdatedHandler(event);
+            }
+        });
     }
 
     /**
@@ -206,6 +207,8 @@ public abstract class ItemsListGrid<I> extends ListGrid {
      * @param event
      */
     protected abstract void selectionChangedHandler(SelectionEvent event);
+
+    protected abstract void selectionUpdatedHandler(SelectionUpdatedEvent event);
 
     /**
      * Apply the local filter to the grid.

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
@@ -57,6 +57,7 @@ import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
 import com.smartgwt.client.widgets.grid.SortNormalizer;
 import com.smartgwt.client.widgets.grid.events.SelectionEvent;
+import com.smartgwt.client.widgets.grid.events.SelectionUpdatedEvent;
 import com.smartgwt.client.widgets.menu.Menu;
 import com.smartgwt.client.widgets.menu.MenuItem;
 import com.smartgwt.client.widgets.menu.events.ClickHandler;
@@ -94,6 +95,7 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
         this.setSort(DEFAULT_SORT);
     }
 
+    @Override
     protected void selectionChangedHandler(SelectionEvent event) {
         if (event.getState() && !fetchingData) {
             ListGridRecord record = event.getRecord();
@@ -103,8 +105,18 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
     }
 
     @Override
+    protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
+        ListGridRecord[] selectedRecords = this.getSelectedRecords();
+        ArrayList<Integer> selectedJobsIds = new ArrayList<>();
+        for (ListGridRecord selectedRecord : selectedRecords) {
+            selectedJobsIds.add(JobRecord.getJob(selectedRecord).getId());
+        }
+        controller.getModel().setSelectedJobsIds(selectedJobsIds);
+    }
+
+    @Override
     public void jobsUpdated(Map<Integer, Job> jobs) {
-        Job selectedJob = this.controller.getModel().getSelectedJob();
+        ArrayList selectedJobsIds = this.controller.getModel().getSelectedJobsIds();
 
         RecordList data = new RecordList();
         for (Job j : jobs.values()) {
@@ -112,7 +124,7 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
             this.columnsFactory.buildRecord(j, jobRecord);
             data.add(jobRecord);
 
-            if (j.equals(selectedJob)) {
+            if (selectedJobsIds != null && selectedJobsIds.contains(j.getId())) {
                 jobRecord.setAttribute("isSelected", true);
             }
         }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
@@ -32,6 +32,7 @@ import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.job
 import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.jobs.JobsColumnsFactory.STATE_ATTR;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.Job;
@@ -107,7 +108,7 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
     @Override
     protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
         ListGridRecord[] selectedRecords = this.getSelectedRecords();
-        ArrayList<Integer> selectedJobsIds = new ArrayList<>();
+        List<Integer> selectedJobsIds = new ArrayList<>(selectedRecords.length);
         for (ListGridRecord selectedRecord : selectedRecords) {
             selectedJobsIds.add(JobRecord.getJob(selectedRecord).getId());
         }
@@ -116,7 +117,7 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
 
     @Override
     public void jobsUpdated(Map<Integer, Job> jobs) {
-        ArrayList selectedJobsIds = this.controller.getModel().getSelectedJobsIds();
+        List<Integer> selectedJobsIds = this.controller.getModel().getSelectedJobsIds();
 
         RecordList data = new RecordList();
         for (Job j : jobs.values()) {

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -168,7 +168,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     public void tasksUpdated(List<Task> tasks, long totalTasks) {
         this.visuButtons.clear();
-        ArrayList selectedTasksIds = this.controller.getModel().getSelectedTasksIds();
+        List<String> selectedTasksIds = this.controller.getModel().getSelectedTasksIds();
 
         RecordList data = new RecordList();
         for (Task t : tasks) {
@@ -461,7 +461,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
         ListGridRecord[] selectedRecords = this.getSelectedRecords();
-        ArrayList<String> selectedTasksIds = new ArrayList<>();
+        List<String> selectedTasksIds = new ArrayList<>(selectedRecords.length);
         for (ListGridRecord selectedRecord : selectedRecords) {
             Task task = TaskRecord.getTask(selectedRecord);
             selectedTasksIds.add(task.getJobId() + "_" + task.getId());

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -30,6 +30,7 @@ import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tas
 import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.TasksColumnsFactory.NAME_ATTR;
 import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.TasksColumnsFactory.STATUS_ATTR;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,6 @@ import com.smartgwt.client.data.Record;
 import com.smartgwt.client.data.RecordList;
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.ListGridFieldType;
-import com.smartgwt.client.types.SelectionStyle;
 import com.smartgwt.client.types.SortDirection;
 import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.IButton;
@@ -65,6 +65,7 @@ import com.smartgwt.client.widgets.grid.CellFormatter;
 import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
 import com.smartgwt.client.widgets.grid.events.SelectionEvent;
+import com.smartgwt.client.widgets.grid.events.SelectionUpdatedEvent;
 import com.smartgwt.client.widgets.layout.HLayout;
 import com.smartgwt.client.widgets.layout.VLayout;
 import com.smartgwt.client.widgets.menu.Menu;
@@ -111,7 +112,6 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     public void build() {
         super.build();
-        this.setSelectionType(SelectionStyle.SINGLE);
         this.setSelectionProperty("isSelected");
         this.sort(TasksColumnsFactory.ID_ATTR.getName(), SortDirection.ASCENDING);
         this.setShowRecordComponents(true);
@@ -168,18 +168,17 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     public void tasksUpdated(List<Task> tasks, long totalTasks) {
         this.visuButtons.clear();
-        Task selectedTask = this.controller.getModel().getSelectedTask();
+        ArrayList selectedTasksIds = this.controller.getModel().getSelectedTasksIds();
 
         RecordList data = new RecordList();
-        TaskRecord selectedRecord = null;
         for (Task t : tasks) {
             TaskRecord record = new TaskRecord(t);
             this.columnsFactory.buildRecord(t, record);
             data.add(record);
 
-            if (t.equals(selectedTask)) {
+            String key = t.getJobId() + "_" + t.getId();
+            if (selectedTasksIds != null && selectedTasksIds.contains(key)) {
                 record.setAttribute("isSelected", true);
-                selectedRecord = record;
             }
         }
 
@@ -457,6 +456,17 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
             Task task = TaskRecord.getTask(record);
             controller.selectTask(task);
         }
+    }
+
+    @Override
+    protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
+        ListGridRecord[] selectedRecords = this.getSelectedRecords();
+        ArrayList<String> selectedTasksIds = new ArrayList<>();
+        for (ListGridRecord selectedRecord : selectedRecords) {
+            Task task = TaskRecord.getTask(selectedRecord);
+            selectedTasksIds.add(task.getJobId() + "_" + task.getId());
+        }
+        controller.getModel().setSelectedTasksIds(selectedTasksIds);
     }
 
 }


### PR DESCRIPTION
This PR includes:
- Fix the issue of multiple selections being cleared upon automatic refresh on the Job Execution list.
- Enable multiple selection as well in task-centric execution view.

fixes #405 