### PR TITLE
Fix contextual menu actions on task-centric view

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/TasksController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/TasksController.java
@@ -146,8 +146,7 @@ public class TasksController {
      * Kill a task within a job 
      * @param taskName task name
      */
-    public void killTask(final String taskName) {
-        final Integer jobId = this.model.getParentModel().getExecutionsModel().getJobsModel().getSelectedJob().getId();
+    public void killTask(final String taskName, final Integer jobId) {
         String sessionId = LoginModel.getInstance().getSessionId();
         SchedulerServiceAsync scheduler = Scheduler.getSchedulerService();
         scheduler.killTask(sessionId, jobId, taskName, new AsyncCallback<Boolean>() {
@@ -166,18 +165,15 @@ public class TasksController {
         });
     }
 
-    public void restartInErrorTask(final String taskName) {
-        restartTask(taskName, RestartType.IN_ERROR_TASK);
+    public void restartInErrorTask(final String taskName, final Integer jobId) {
+        restartTask(taskName, jobId, RestartType.IN_ERROR_TASK);
     }
 
-    public void restartRunningTask(final String taskName) {
-        restartTask(taskName, RestartType.RUNNING_TASK);
+    public void restartRunningTask(final String taskName, final Integer jobId) {
+        restartTask(taskName, jobId, RestartType.RUNNING_TASK);
     }
 
-    protected void restartTask(String taskName, RestartType restartType) {
-        ExecutionsModel executionsModel = this.model.getParentModel().getExecutionsModel();
-        Job selectedJob = executionsModel.getSelectedJob();
-        Integer jobId = selectedJob.getId();
+    protected void restartTask(String taskName, Integer jobId, RestartType restartType) {
 
         String sessionId = LoginModel.getInstance().getSessionId();
         SchedulerServiceAsync scheduler = Scheduler.getSchedulerService();
@@ -227,8 +223,7 @@ public class TasksController {
      * Preempt a task within a job 
      * @param taskName task name
      */
-    public void preemptTask(final String taskName) {
-        final Integer jobId = this.model.getParentModel().getExecutionsModel().getJobsModel().getSelectedJob().getId();
+    public void preemptTask(final String taskName, final Integer jobId) {
         String sessionId = LoginModel.getInstance().getSessionId();
         SchedulerServiceAsync scheduler = Scheduler.getSchedulerService();
         scheduler.preemptTask(sessionId, jobId, taskName, new AsyncCallback<Boolean>() {
@@ -249,10 +244,7 @@ public class TasksController {
      * Mark in-error task as finished and resume job
      * @param taskName task name
      */
-    public void markAsFinishedAndResume(final String taskName) {
-        ExecutionsModel executionsModel = this.model.getParentModel().getExecutionsModel();
-        Job selectedJob = executionsModel.getSelectedJob();
-        final Integer jobId = selectedJob.getId();
+    public void markAsFinishedAndResume(final String taskName, final Integer jobId) {
 
         String sessionId = LoginModel.getInstance().getSessionId();
         SchedulerServiceAsync scheduler = Scheduler.getSchedulerService();

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksModel.java
@@ -47,8 +47,6 @@ public class TasksModel {
 
     protected Task selectedTask;
 
-    protected List<String> selectedTasksIds = null;
-
     protected ArrayList<TaskSelectedListener> tasksSelectedListeners = null;
 
     protected ArrayList<TasksUpdatedListener> tasksUpdatedListeners = null;
@@ -215,13 +213,5 @@ public class TasksModel {
 
     public void setTasksNavigationModel(TasksNavigationModel tasksNavigationModel) {
         this.tasksNavigationModel = tasksNavigationModel;
-    }
-
-    public List<String> getSelectedTasksIds() {
-        return selectedTasksIds;
-    }
-
-    public void setSelectedTasksIds(List<String> selectedTasksIds) {
-        this.selectedTasksIds = selectedTasksIds;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -113,7 +113,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     public void build() {
         super.build();
         this.setSelectionProperty("isSelected");
-        this.sort(TasksColumnsFactory.ID_ATTR.getName(), SortDirection.ASCENDING);
+        this.sort(TasksCentricColumnsFactory.JOB_ID_ATTR.getName(), SortDirection.DESCENDING);
         this.setShowRecordComponents(true);
         this.setShowRecordComponentsByCell(true);
     }
@@ -359,12 +359,13 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     protected void buildCellContextualMenu(Menu menu) {
         final String taskName = this.getSelectedRecord().getAttributeAsString(NAME_ATTR.getName());
         final String taskStatusName = this.getSelectedRecord().getAttributeAsString(STATUS_ATTR.getName());
+        final Integer jobId = (int) TaskRecord.getTask(this.getSelectedRecord()).getJobId();
 
         MenuItem restartInErrorTask = new MenuItem("Restart In-Error Task");
         restartInErrorTask.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             @Override
             public void onClick(MenuItemClickEvent event) {
-                controller.restartInErrorTask(taskName);
+                controller.restartInErrorTask(taskName, jobId);
             }
         });
 
@@ -372,7 +373,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
         restartRunningTask.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             @Override
             public void onClick(MenuItemClickEvent event) {
-                controller.restartRunningTask(taskName);
+                controller.restartRunningTask(taskName, jobId);
             }
         });
 
@@ -380,21 +381,21 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
         preempt.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             @Override
             public void onClick(MenuItemClickEvent event) {
-                controller.preemptTask(taskName);
+                controller.preemptTask(taskName, jobId);
             }
         });
         MenuItem kill = new MenuItem("Kill");
         kill.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             @Override
             public void onClick(MenuItemClickEvent event) {
-                controller.killTask(taskName);
+                controller.killTask(taskName, jobId);
             }
         });
         MenuItem markAsFinishedAndResume = new MenuItem("Mark as finished and Resume");
         markAsFinishedAndResume.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
             @Override
             public void onClick(MenuItemClickEvent event) {
-                controller.markAsFinishedAndResume(taskName);
+                controller.markAsFinishedAndResume(taskName, jobId);
             }
         });
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -49,10 +49,10 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.ItemsListG
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.smartgwt.client.data.Record;
 import com.smartgwt.client.data.RecordList;
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.ListGridFieldType;
+import com.smartgwt.client.types.SelectionStyle;
 import com.smartgwt.client.types.SortDirection;
 import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.IButton;
@@ -112,6 +112,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     public void build() {
         super.build();
+        this.setSelectionType(SelectionStyle.SINGLE);
         this.setSelectionProperty("isSelected");
         this.sort(TasksCentricColumnsFactory.JOB_ID_ATTR.getName(), SortDirection.DESCENDING);
         this.setShowRecordComponents(true);
@@ -168,7 +169,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     public void tasksUpdated(List<Task> tasks, long totalTasks) {
         this.visuButtons.clear();
-        List<String> selectedTasksIds = this.controller.getModel().getSelectedTasksIds();
+        Task selectedTask = this.controller.getModel().getSelectedTask();
 
         RecordList data = new RecordList();
         for (Task t : tasks) {
@@ -176,8 +177,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
             this.columnsFactory.buildRecord(t, record);
             data.add(record);
 
-            String key = t.getJobId() + "_" + t.getId();
-            if (selectedTasksIds != null && selectedTasksIds.contains(key)) {
+            if (t.equals(selectedTask)) {
                 record.setAttribute("isSelected", true);
             }
         }
@@ -453,7 +453,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
     @Override
     protected void selectionChangedHandler(SelectionEvent event) {
         if (event.getState() && !fetchingData) {
-            Record record = event.getRecord();
+            ListGridRecord record = event.getRecord();
             Task task = TaskRecord.getTask(record);
             controller.selectTask(task);
         }
@@ -461,13 +461,7 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
 
     @Override
     protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
-        ListGridRecord[] selectedRecords = this.getSelectedRecords();
-        List<String> selectedTasksIds = new ArrayList<>(selectedRecords.length);
-        for (ListGridRecord selectedRecord : selectedRecords) {
-            Task task = TaskRecord.getTask(selectedRecord);
-            selectedTasksIds.add(task.getJobId() + "_" + task.getId());
-        }
-        controller.getModel().setSelectedTasksIds(selectedTasksIds);
+
     }
 
 }


### PR DESCRIPTION
- Actions on task-centric view (kill, preempt, restart) were wrongly using the "selectedJob" as jobId. They should use the jobId corresponding to the selected Task instead.
- Also fixed the sorting attribute for better visualization.
- Also rolled back multiple selection. Only single-selection will be enabled in task-centric view.

