### PR TITLE
Enable batch job priority modifications on scheduler portal

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/SchedulerServiceImpl.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/SchedulerServiceImpl.java
@@ -1340,7 +1340,7 @@ public class SchedulerServiceImpl extends Service implements SchedulerService {
             try {
                 inputStream = action.apply(restClientProxy, jobId);
 
-                if (Boolean.parseBoolean(convertToString(inputStream))) {
+                if (actionName.startsWith("job set") || Boolean.parseBoolean(convertToString(inputStream))) {
                     success++;
                 } else {
                     failures++;


### PR DESCRIPTION
Handle NPE when modifying job priority in batch:
Unlike other job-wise operations of the popup menu (pause, resume, kill), `setPriorityByName()` does not return a boolean, so the generic `executeFunction()` expected a value (boolean) and received a null.