### PR TITLE
Fix update dynamic parameters of node source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/EditDynamicParametersWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/EditDynamicParametersWindow.java
@@ -39,6 +39,7 @@ import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.form.fields.CheckboxItem;
 import com.smartgwt.client.widgets.form.fields.FormItem;
 import com.smartgwt.client.widgets.form.fields.HiddenItem;
+import com.smartgwt.client.widgets.form.fields.SelectItem;
 import com.smartgwt.client.widgets.form.fields.TextAreaItem;
 import com.smartgwt.client.widgets.form.fields.TextItem;
 import com.smartgwt.client.widgets.layout.HLayout;
@@ -163,11 +164,16 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
 
         formItem.disable();
 
-        // since the form item is disabled, we need to add the item content in
-        // a hidden item for it to be submitted with the form
-        HiddenItem hiddenItem = new HiddenItem(formItem.getName());
-        hiddenItem.setValue(formItem.getValue());
-        allFormItemsWithHiddenFields.add(hiddenItem);
+        // when a form item is disabled, it will not be given as parameter of
+        // the submitted form, so we need to add the item content in a hidden
+        // item for it to be submitted with the form. This is true for all
+        // form items but the SelectItem (they are submitted as part of the
+        // form even if disabled), this is why we make a special case.
+        if (!(formItem instanceof SelectItem)) {
+            HiddenItem hiddenItem = new HiddenItem(formItem.getName());
+            hiddenItem.setValue(formItem.getValue());
+            allFormItemsWithHiddenFields.add(hiddenItem);
+        }
     }
 
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/NSCreationServlet.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/NSCreationServlet.java
@@ -116,7 +116,7 @@ public class NSCreationServlet extends HttpServlet {
                     } else if (formFieldName.equals("nodesRecoverable")) {
                         nodesRecoverable = formFieldValue;
                     } else if (formFieldName.equals("deploy")) {
-                        deployNodeSource = formFieldValue.equals(Boolean.TRUE.toString());
+                        deployNodeSource = Boolean.parseBoolean(formFieldValue);
                     } else if (formFieldName.equals("nodeSourceAction")) {
                         nodeSourceAction = NodeSourceAction.getEnum(formFieldValue);
                     } else if (formFieldName.equals("infra")) {


### PR DESCRIPTION
- issue: when hitting 'Apply Modifications' of the Edit Dynamic Parameters window of node source, an error would often occur: 'No Policy selected'
- the infrastructure and policy types were submitted as part of the form parameters twice, because, unlike the other form items, disabling a GWT SelectItem does not prevent it to be submitted when the form is submitted. When the issue appeared, one occurence of the parameter contained the right value, and the other on was empty. Depending on the order in which the two identical parameters were read, the issue could come up.
- the fix is to avoid passing a second occurence of the form item for the SelectItems corresponding to the infrastructure and policy types.