### PR TITLE
Prevent auto scroll when context menu called

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/Tile.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/Tile.java
@@ -97,7 +97,7 @@ public class Tile extends Image {
     public void onBrowserEvent(Event event) {
         switch (DOM.eventGetType(event)) {
             case Event.ONCONTEXTMENU:
-
+                compactView.setDoNotScroll(true);
                 final Menu menu = ContextMenu.createContextMenuFromCompactView(compactView.getController(), related);
 
                 menu.moveTo(event.getClientX(), event.getClientY());


### PR DESCRIPTION
When context menu is called on one of the nodes/hosts/nodesources in CompactView in rm portal, it was auto scroll so that selected item appears in the first line. This PR fixes it.