### PR TITLE
Fix selected infrastructure/policy when importing node source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/window/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/window/NodeSourceWindow.java
@@ -700,8 +700,8 @@ public abstract class NodeSourceWindow {
                 fillFocusedPluginValues(selectItemValues, focusedInfrastructurePlugin);
                 handleAdditionalInfrastructureFormItems(selectItemValues, focusedInfrastructurePlugin);
                 NodeSourceWindow.this.infrastructureSelectItem.setValueMap(selectItemValues);
-                NodeSourceWindow.this.infrastructureSelectItem.setValue(getPluginShortName(focusedInfrastructurePlugin));
                 NodeSourceWindow.this.previousSelectedInfrastructure = focusedInfrastructurePlugin.getPluginName();
+                NodeSourceWindow.this.infrastructureSelectItem.setValue(NodeSourceWindow.this.previousSelectedInfrastructure);
 
                 NodeSourceWindow.this.allFormItems.add(new SpacerItem());
                 selectItemValues.clear();
@@ -712,8 +712,8 @@ public abstract class NodeSourceWindow {
                 fillFocusedPluginValues(selectItemValues, focusedPolicyPlugin);
                 handleAdditionalPolicyFormItems(selectItemValues, focusedPolicyPlugin);
                 NodeSourceWindow.this.policySelectItem.setValueMap(selectItemValues);
-                NodeSourceWindow.this.policySelectItem.setValue(getPluginShortName(focusedPolicyPlugin));
                 NodeSourceWindow.this.previousSelectedPolicy = focusedPolicyPlugin.getPluginName();
+                NodeSourceWindow.this.policySelectItem.setValue(NodeSourceWindow.this.previousSelectedPolicy);
 
                 NodeSourceWindow.this.infrastructureSelectItem.addChangedHandler(changedEvent -> resetFormForInfrastructureSelectChange());
                 NodeSourceWindow.this.policySelectItem.addChangedHandler(changedEvent -> resetFormForPolicySelectChange());


### PR DESCRIPTION
- when importing a node source, the selected infrastructure and policy are automatically set. The issue fixed by this commit was that the default selected item was set by value instead of being set by key (swap between key and value during refactoring), which sould create an additional, fake, infrastructure/policy, resulting in an import error.