### PR TITLE
Fix node source edit window message

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
@@ -121,7 +121,7 @@ public class EditNodeSourceWindow extends NodeSourceWindow {
             this.allFormItems = modifyFormItemsAfterCreation(focusedInfrastructurePlugin, focusedPolicyPlugin);
 
             this.nodeSourcePluginsForm.setFields(this.allFormItems.toArray(new FormItem[this.allFormItems.size()]));
-            this.nodeSourceWindowLabel.hide();
+            this.nodeSourcePluginsWaitingLabel.hide();
             this.nodeSourcePluginsForm.show();
 
         }, this.window::hide);


### PR DESCRIPTION
- the wrong variable was used to hide the waiting message when the node source configuration is being retrieved from the resource manager. Instead, the explanatory message of the edit window was hidden.