### PR TITLE
Change catalog request when exporting node source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/ExportToCatalogConfirmWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/ExportToCatalogConfirmWindow.java
@@ -53,6 +53,7 @@ import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Hidden;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.smartgwt.client.types.Alignment;
@@ -71,7 +72,7 @@ public class ExportToCatalogConfirmWindow extends Window {
 
     public static final int WINDOW_WIDTH = 680;
 
-    public static final int WINDOW_HEIGHT = 200;
+    public static final int WINDOW_HEIGHT = 210;
 
     public static final String SELECT_A_BUCKET_OPTION = "Select a bucket";
 
@@ -123,7 +124,6 @@ public class ExportToCatalogConfirmWindow extends Window {
 
         this.windowLabel = new Label("Choose the catalog bucket in which to publish the Node Source " + nodeSourceName);
         this.windowLabel.setHeight(30);
-        this.windowLabel.setMargin(5);
 
         HorizontalPanel exportInfoPanel = new HorizontalPanel();
         exportInfoPanel.setHeight("80px");
@@ -139,12 +139,14 @@ public class ExportToCatalogConfirmWindow extends Window {
         exportInfoPanel.add(commitLabel);
         this.commitMessage = new TextBox();
         exportInfoPanel.add(this.commitMessage);
-
         this.revisionLabel = new Label(INITIAL_COMMIT_MESSAGE);
         this.revisionLabel.setHeight("80px");
         this.revisionLabel.setValign(VerticalAlignment.TOP);
         this.revisionLabel.setAlign(Alignment.LEFT);
-        exportInfoPanel.add(this.revisionLabel);
+        ScrollPanel scrollPanel = new ScrollPanel();
+        scrollPanel.setHeight("80px");
+        scrollPanel.add(this.revisionLabel);
+        exportInfoPanel.add(scrollPanel);
 
         HLayout buttons = new HLayout();
         buttons.setHeight(40);
@@ -161,6 +163,7 @@ public class ExportToCatalogConfirmWindow extends Window {
         VLayout layout = new VLayout();
         layout.setAlign(VerticalAlignment.TOP);
         layout.setMargin(10);
+        layout.setMembersMargin(10);
         layout.addMember(this.windowLabel);
         layout.addMember(exportInfoPanel);
         layout.addMember(buttons);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
@@ -28,16 +28,10 @@ package org.ow2.proactive_grid_cloud_portal.rm.server.serialization;
 import static org.ow2.proactive_grid_cloud_portal.rm.shared.CatalogConstants.*;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.UUID;
-import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -68,10 +62,6 @@ public class CatalogRequestBuilder {
             builder.append("/resources?");
         }
         return builder.toString();
-    }
-
-    private void appendParameters(StringBuilder builder, String... paramPairs) {
-        builder.append(Arrays.stream(paramPairs).collect(Collectors.joining("&")));
     }
 
     public CloseableHttpResponse postNodeSourceRequestToCatalog(CatalogObjectAction catalogObjectAction, String fullUri)

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
@@ -64,17 +64,13 @@ public class CatalogRequestBuilder {
         return builder.toString();
     }
 
-    public CloseableHttpResponse postNodeSourceRequestToCatalog(CatalogObjectAction catalogObjectAction, String fullUri)
+    public CloseableHttpResponse postNodeSourceRequestToCatalog(String fullUri)
             throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException, IOException {
-        HttpPost postNodeSource = buildCatalogRequest(catalogObjectAction, fullUri);
+        HttpPost postNodeSource = buildCatalogRequest(fullUri);
         return getHttpClientBuilder().build().execute(postNodeSource);
     }
 
-    private String paramPair(String param, String value) {
-        return param + "=" + value;
-    }
-
-    private HttpPost buildCatalogRequest(CatalogObjectAction catalogObjectActio, String fullUri) {
+    private HttpPost buildCatalogRequest(String fullUri) {
         String boundary = "---------------" + UUID.randomUUID().toString();
         HttpPost post = new HttpPost(fullUri);
         post.addHeader("Accept", "application/json");

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/ExportNodeSourceToCatalogServlet.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/ExportNodeSourceToCatalogServlet.java
@@ -81,7 +81,7 @@ public class ExportNodeSourceToCatalogServlet extends HttpServlet {
     private void postRequestAndHandleResponse(HttpServletResponse response, CatalogObjectAction catalogObjectAction,
             CatalogRequestBuilder catalogRequestBuilder, String requestUri)
             throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-        try (CloseableHttpResponse httpResponse = catalogRequestBuilder.postNodeSourceRequestToCatalog(catalogObjectAction.getSessionId(),
+        try (CloseableHttpResponse httpResponse = catalogRequestBuilder.postNodeSourceRequestToCatalog(catalogObjectAction,
                                                                                                        requestUri)) {
             new BasicResponseHandler().handleResponse(httpResponse);
         } catch (HttpResponseException e) {

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/ExportNodeSourceToCatalogServlet.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/ExportNodeSourceToCatalogServlet.java
@@ -81,8 +81,7 @@ public class ExportNodeSourceToCatalogServlet extends HttpServlet {
     private void postRequestAndHandleResponse(HttpServletResponse response, CatalogObjectAction catalogObjectAction,
             CatalogRequestBuilder catalogRequestBuilder, String requestUri)
             throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-        try (CloseableHttpResponse httpResponse = catalogRequestBuilder.postNodeSourceRequestToCatalog(catalogObjectAction,
-                                                                                                       requestUri)) {
+        try (CloseableHttpResponse httpResponse = catalogRequestBuilder.postNodeSourceRequestToCatalog(requestUri)) {
             new BasicResponseHandler().handleResponse(httpResponse);
         } catch (HttpResponseException e) {
             logErrorAndWriteResponseToClient(e, response);


### PR DESCRIPTION
- pass parameter in the body instead of the URL so that the commit message does not need to be encoded. This was an issue as the catalog does not decode the commit message on the the other side: non standard characters would result in unreadable characters in the commit messages seen in the catalog portal.