### PR TITLE
Fix condition to export a new node source in the catalog

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
@@ -70,7 +70,7 @@ public class CatalogRequestBuilder {
         return getHttpClientBuilder().build().execute(postNodeSource);
     }
 
-    private HttpPost buildCatalogRequest(String fullUri) {
+    protected HttpPost buildCatalogRequest(String fullUri) {
         String boundary = "---------------" + UUID.randomUUID().toString();
         HttpPost post = new HttpPost(fullUri);
         post.addHeader("Accept", "application/json");

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilder.java
@@ -83,7 +83,7 @@ public class CatalogRequestBuilder {
         builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
         builder.addPart("file", new FileBody(this.catalogObjectAction.getNodeSourceJsonFile()));
         builder.addTextBody(COMMIT_MESSAGE_PARAM, this.catalogObjectAction.getCommitMessage());
-        if (this.catalogObjectAction.isRevised()) {
+        if (!this.catalogObjectAction.isRevised()) {
             builder.addTextBody(NAME_PARAM, this.catalogObjectAction.getNodeSourceName());
             builder.addTextBody(KIND_PARAM, this.catalogObjectAction.getKind());
             builder.addTextBody(OBJECT_CONTENT_TYPE_PARAM, this.catalogObjectAction.getObjectContentType());

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/CatalogConstants.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/CatalogConstants.java
@@ -47,7 +47,7 @@ public class CatalogConstants {
 
     public static final String NAME_PARAM = "name";
 
-    public static final String FILE_CONTENT_PARAM = "fileContent";
+    public static final String FILE_CONTENT_PARAM = "file";
 
     public static final String KIND_PARAM = "kind";
 

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
@@ -1,4 +1,37 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
 package org.ow2.proactive_grid_cloud_portal.rm.server.serialization;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.http.client.methods.HttpPost;
 import org.junit.Before;
@@ -8,13 +41,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.CatalogConstants;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CatalogRequestBuilderTest {
@@ -22,17 +48,15 @@ public class CatalogRequestBuilderTest {
     @Mock
     private CatalogObjectAction catalogObjectAction;
 
-    private File jsonFile;
-
     private CatalogRequestBuilder catalogRequestBuilder;
 
     @Before
     public void setup() throws IOException {
         this.catalogRequestBuilder = new CatalogRequestBuilder(catalogObjectAction);
-        this.jsonFile = Files.createTempFile("nodesource", ".json").toFile();
+        File jsonFile = Files.createTempFile("nodesource", ".json").toFile();
         when(catalogObjectAction.getSessionId()).thenReturn("A4D5ca7vCAC582113WQCjmnW28");
         when(catalogObjectAction.getNodeSourceName()).thenReturn("myNodeSource");
-        when(catalogObjectAction.getNodeSourceJsonFile()).thenReturn(this.jsonFile);
+        when(catalogObjectAction.getNodeSourceJsonFile()).thenReturn(jsonFile);
         when(catalogObjectAction.getCommitMessage()).thenReturn("commit message");
         when(catalogObjectAction.getKind()).thenReturn("NodeSource");
         when(catalogObjectAction.getObjectContentType()).thenReturn("application/json");
@@ -44,8 +68,10 @@ public class CatalogRequestBuilderTest {
         HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
         String string = getMultipartEntityString(httpPost);
         checkThatRequestContainsRegularParameters(string);
-        assertThat("Request contains the " + CatalogConstants.KIND_PARAM + " parameter whereas it shouldn't", !string.contains(CatalogConstants.KIND_PARAM));
-        assertThat("Request contains the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter whereas it shouldn't", !string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+        assertThat("Request contains the " + CatalogConstants.KIND_PARAM + " parameter whereas it shouldn't",
+                   !string.contains(CatalogConstants.KIND_PARAM));
+        assertThat("Request contains the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM +
+                   " parameter whereas it shouldn't", !string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
     }
 
     @Test
@@ -54,13 +80,17 @@ public class CatalogRequestBuilderTest {
         HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
         String string = getMultipartEntityString(httpPost);
         checkThatRequestContainsRegularParameters(string);
-        assertThat("Request does not contain the " + CatalogConstants.KIND_PARAM + " parameter", string.contains(CatalogConstants.KIND_PARAM));
-        assertThat("Request does not contain the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter", string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.KIND_PARAM + " parameter",
+                   string.contains(CatalogConstants.KIND_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter",
+                   string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
     }
 
     private void checkThatRequestContainsRegularParameters(String string) {
-        assertThat("Request does not contain the " + CatalogConstants.FILE_CONTENT_PARAM + " parameter", string.contains(CatalogConstants.FILE_CONTENT_PARAM));
-        assertThat("Request does not contain the " + CatalogConstants.COMMIT_MESSAGE_PARAM + " parameter", string.contains(CatalogConstants.COMMIT_MESSAGE_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.FILE_CONTENT_PARAM + " parameter",
+                   string.contains(CatalogConstants.FILE_CONTENT_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.COMMIT_MESSAGE_PARAM + " parameter",
+                   string.contains(CatalogConstants.COMMIT_MESSAGE_PARAM));
     }
 
     private String getMultipartEntityString(HttpPost httpPost) throws IOException {

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.http.client.methods.HttpPost;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,31 +67,32 @@ public class CatalogRequestBuilderTest {
     public void testParametersAreSetForRevisedNodeSourceRequest() throws IOException {
         when(this.catalogObjectAction.isRevised()).thenReturn(true);
         HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
-        String string = getMultipartEntityString(httpPost);
-        checkThatRequestContainsRegularParameters(string);
+        String entityStringContent = getMultipartEntityString(httpPost);
+        checkThatRequestContainsRegularParameters(entityStringContent);
         assertThat("Request contains the " + CatalogConstants.KIND_PARAM + " parameter whereas it shouldn't",
-                   !string.contains(CatalogConstants.KIND_PARAM));
+                   CoreMatchers.not(entityStringContent.contains(CatalogConstants.KIND_PARAM)));
         assertThat("Request contains the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM +
-                   " parameter whereas it shouldn't", !string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+                   " parameter whereas it shouldn't",
+                   CoreMatchers.not(entityStringContent.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM)));
     }
 
     @Test
     public void testParametersAreSetForNewNodeSourceRequest() throws IOException {
         when(this.catalogObjectAction.isRevised()).thenReturn(false);
         HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
-        String string = getMultipartEntityString(httpPost);
-        checkThatRequestContainsRegularParameters(string);
+        String entityStringContent = getMultipartEntityString(httpPost);
+        checkThatRequestContainsRegularParameters(entityStringContent);
         assertThat("Request does not contain the " + CatalogConstants.KIND_PARAM + " parameter",
-                   string.contains(CatalogConstants.KIND_PARAM));
+                   entityStringContent.contains(CatalogConstants.KIND_PARAM));
         assertThat("Request does not contain the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter",
-                   string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+                   entityStringContent.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
     }
 
-    private void checkThatRequestContainsRegularParameters(String string) {
+    private void checkThatRequestContainsRegularParameters(String entityStringContent) {
         assertThat("Request does not contain the " + CatalogConstants.FILE_CONTENT_PARAM + " parameter",
-                   string.contains(CatalogConstants.FILE_CONTENT_PARAM));
+                   entityStringContent.contains(CatalogConstants.FILE_CONTENT_PARAM));
         assertThat("Request does not contain the " + CatalogConstants.COMMIT_MESSAGE_PARAM + " parameter",
-                   string.contains(CatalogConstants.COMMIT_MESSAGE_PARAM));
+                   entityStringContent.contains(CatalogConstants.COMMIT_MESSAGE_PARAM));
     }
 
     private String getMultipartEntityString(HttpPost httpPost) throws IOException {

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/server/serialization/CatalogRequestBuilderTest.java
@@ -1,0 +1,72 @@
+package org.ow2.proactive_grid_cloud_portal.rm.server.serialization;
+
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ow2.proactive_grid_cloud_portal.rm.shared.CatalogConstants;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CatalogRequestBuilderTest {
+
+    @Mock
+    private CatalogObjectAction catalogObjectAction;
+
+    private File jsonFile;
+
+    private CatalogRequestBuilder catalogRequestBuilder;
+
+    @Before
+    public void setup() throws IOException {
+        this.catalogRequestBuilder = new CatalogRequestBuilder(catalogObjectAction);
+        this.jsonFile = Files.createTempFile("nodesource", ".json").toFile();
+        when(catalogObjectAction.getSessionId()).thenReturn("A4D5ca7vCAC582113WQCjmnW28");
+        when(catalogObjectAction.getNodeSourceName()).thenReturn("myNodeSource");
+        when(catalogObjectAction.getNodeSourceJsonFile()).thenReturn(this.jsonFile);
+        when(catalogObjectAction.getCommitMessage()).thenReturn("commit message");
+        when(catalogObjectAction.getKind()).thenReturn("NodeSource");
+        when(catalogObjectAction.getObjectContentType()).thenReturn("application/json");
+    }
+
+    @Test
+    public void testParametersAreSetForRevisedNodeSourceRequest() throws IOException {
+        when(this.catalogObjectAction.isRevised()).thenReturn(true);
+        HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
+        String string = getMultipartEntityString(httpPost);
+        checkThatRequestContainsRegularParameters(string);
+        assertThat("Request contains the " + CatalogConstants.KIND_PARAM + " parameter whereas it shouldn't", !string.contains(CatalogConstants.KIND_PARAM));
+        assertThat("Request contains the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter whereas it shouldn't", !string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+    }
+
+    @Test
+    public void testParametersAreSetForNewNodeSourceRequest() throws IOException {
+        when(this.catalogObjectAction.isRevised()).thenReturn(false);
+        HttpPost httpPost = this.catalogRequestBuilder.buildCatalogRequest("http://localhost:8080/catalog");
+        String string = getMultipartEntityString(httpPost);
+        checkThatRequestContainsRegularParameters(string);
+        assertThat("Request does not contain the " + CatalogConstants.KIND_PARAM + " parameter", string.contains(CatalogConstants.KIND_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.OBJECT_CONTENT_TYPE_PARAM + " parameter", string.contains(CatalogConstants.OBJECT_CONTENT_TYPE_PARAM));
+    }
+
+    private void checkThatRequestContainsRegularParameters(String string) {
+        assertThat("Request does not contain the " + CatalogConstants.FILE_CONTENT_PARAM + " parameter", string.contains(CatalogConstants.FILE_CONTENT_PARAM));
+        assertThat("Request does not contain the " + CatalogConstants.COMMIT_MESSAGE_PARAM + " parameter", string.contains(CatalogConstants.COMMIT_MESSAGE_PARAM));
+    }
+
+    private String getMultipartEntityString(HttpPost httpPost) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream((int) httpPost.getEntity().getContentLength());
+        httpPost.getEntity().writeTo(out);
+        return out.toString();
+    }
+
+}


### PR DESCRIPTION
- the condition to add the parameters that define a new node source to be added to the catalog was reversed, and thus not provided when adding a new node source. They were given in addition when a new revision of the node source was pushed to the catalog, but these have no effect.