### PR TITLE
Prevent infrastructure to be imported in policy and the reverse

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -472,7 +472,7 @@ public abstract class NodeSourceWindow {
                 LogModel.getInstance().logImportantMessage("Successfully applied '" + actionDescription +
                                                            "' action to Node Source: " + nodeSourceName);
             } else {
-                handleNodeSourceCreationError(nodeSourceWindowLayout, this.nodeSourceNameText, jsonCallback);
+                handleNodeSourceCreationError(nodeSourceWindowLayout, jsonCallback);
             }
             this.nodeSourcePluginsWaitingLabel.hide();
             this.nodeSourcePluginsForm.show();
@@ -553,6 +553,7 @@ public abstract class NodeSourceWindow {
 
     private void replacePolicyItemsInItemList(PluginDescriptor policyPluginDescriptor,
             List<FormItem> allNodeSourcePluginsFormItems) {
+        validatePolicyNameOrFail(policyPluginDescriptor.getPluginName());
         allNodeSourcePluginsFormItems.stream()
                                      .filter(formItem -> formItem.getName()
                                                                  .startsWith(policyPluginDescriptor.getPluginName()))
@@ -569,6 +570,16 @@ public abstract class NodeSourceWindow {
         resetFormForPolicySelectChange();
     }
 
+    private void validatePolicyNameOrFail(String policyPluginName) {
+        if (this.controller.getModel()
+                           .getSupportedPolicies()
+                           .values()
+                           .stream()
+                           .noneMatch(pluginDescriptor -> pluginDescriptor.getPluginName().equals(policyPluginName))) {
+            throw new IllegalArgumentException("Policy " + policyPluginName + " does not exist");
+        }
+    }
+
     public void replaceInfrastructureItems(PluginDescriptor infrastructurePluginDescriptor) {
         List<FormItem> allNodeSourcePluginsFormItems = Arrays.stream(this.nodeSourcePluginsForm.getFields())
                                                              .collect(Collectors.toList());
@@ -578,6 +589,7 @@ public abstract class NodeSourceWindow {
 
     private void replaceInfrastructureItemsInItemList(PluginDescriptor infrastructurePluginDescriptor,
             List<FormItem> allNodeSourcePluginsFormItems) {
+        validateInfrastructureNameOrFail(infrastructurePluginDescriptor.getPluginName());
         allNodeSourcePluginsFormItems.stream()
                                      .filter(formItem -> formItem.getName()
                                                                  .startsWith(infrastructurePluginDescriptor.getPluginName()))
@@ -595,6 +607,17 @@ public abstract class NodeSourceWindow {
         resetFormForInfrastructureSelectChange();
     }
 
+    private void validateInfrastructureNameOrFail(String infrastructurePluginName) {
+        if (this.controller.getModel()
+                           .getSupportedInfrastructures()
+                           .values()
+                           .stream()
+                           .noneMatch(pluginDescriptor -> pluginDescriptor.getPluginName()
+                                                                          .equals(infrastructurePluginName))) {
+            throw new IllegalArgumentException("Infrastructure " + infrastructurePluginName + " does not exist");
+        }
+    }
+
     private int findFormItemIndexByName(String formItemName, List<FormItem> allNodeSourcePluginsFormItems) {
         for (int i = 0; i < allNodeSourcePluginsFormItems.size(); i++) {
             if (allNodeSourcePluginsFormItems.get(i).getName().equals(formItemName)) {
@@ -604,8 +627,7 @@ public abstract class NodeSourceWindow {
         throw new IllegalArgumentException("Form item with name " + formItemName + " does not exist");
     }
 
-    private void handleNodeSourceCreationError(VLayout nodeSourceWindowLayout, TextItem nodeSourceNameItem,
-            JSONObject jsonCallback) {
+    private void handleNodeSourceCreationError(VLayout nodeSourceWindowLayout, JSONObject jsonCallback) {
         String msg;
         if (jsonCallback.get("errorMessage").isString() != null) {
             msg = jsonCallback.get("errorMessage").isString().stringValue();

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportInfrastructureLayout.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportInfrastructureLayout.java
@@ -47,13 +47,17 @@ public class ImportInfrastructureLayout extends ImportLayout {
 
     @Override
     public void handleImport(String infrastructureJsonString) {
-        NodeSourceConfigurationParser nodeSourceConfigurationParser = new NodeSourceConfigurationParser();
-        String importedNodeSourceJsonString = nodeSourceConfigurationParser.wrapInfrastructureJsonString(infrastructureJsonString);
-        PluginDescriptor infrastructurePluginDescriptor = nodeSourceConfigurationParser.parseNodeSourceConfiguration(importedNodeSourceJsonString)
-                                                                                       .getInfrastructurePluginDescriptor();
-        this.nodeSourceWindow.setCreatedFromImport();
-        this.nodeSourceWindow.replaceInfrastructureItems(infrastructurePluginDescriptor);
-        this.nodeSourceWindow.resetCreatedFromImport();
+        try {
+            NodeSourceConfigurationParser nodeSourceConfigurationParser = new NodeSourceConfigurationParser();
+            String importedNodeSourceJsonString = nodeSourceConfigurationParser.wrapInfrastructureJsonString(infrastructureJsonString);
+            PluginDescriptor infrastructurePluginDescriptor = nodeSourceConfigurationParser.parseNodeSourceConfiguration(importedNodeSourceJsonString)
+                                                                                           .getInfrastructurePluginDescriptor();
+            this.nodeSourceWindow.setCreatedFromImport();
+            this.nodeSourceWindow.replaceInfrastructureItems(infrastructurePluginDescriptor);
+            this.nodeSourceWindow.resetCreatedFromImport();
+        } catch (Exception e) {
+            this.nodeSourceWindow.setNodeSourceWindowLabelWithError("Import Infrastructure failed", e);
+        }
     }
 
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportLayout.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportLayout.java
@@ -118,7 +118,7 @@ public abstract class ImportLayout extends VLayout {
 
                 @Override
                 public void onError(Request request, Throwable t) {
-                    ImportLayout.this.nodeSourceWindow.setNodeSourceWindowLabelWithError("Import node source from catalog failed",
+                    ImportLayout.this.nodeSourceWindow.setNodeSourceWindowLabelWithError("Import from catalog failed",
                                                                                          t);
                 }
             }));

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportNodeSourceLayout.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportNodeSourceLayout.java
@@ -53,9 +53,13 @@ public class ImportNodeSourceLayout extends ImportLayout {
 
     @Override
     public void handleImport(String submitResult) {
-        this.nodeSourceWindow.setCreatedFromImport();
-        this.nodeSourceWindow.importNodeSourceFromJson(submitResult);
-        this.nodeSourceWindow.resetCreatedFromImport();
+        try {
+            this.nodeSourceWindow.setCreatedFromImport();
+            this.nodeSourceWindow.importNodeSourceFromJson(submitResult);
+            this.nodeSourceWindow.resetCreatedFromImport();
+        } catch (Exception e) {
+            this.nodeSourceWindow.setNodeSourceWindowLabelWithError("Import Node Source failed", e);
+        }
     }
 
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportPolicyLayout.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportPolicyLayout.java
@@ -47,13 +47,17 @@ public class ImportPolicyLayout extends ImportLayout {
 
     @Override
     public void handleImport(String submitResult) {
-        NodeSourceConfigurationParser nodeSourceConfigurationParser = new NodeSourceConfigurationParser();
-        String importedNodeSourceJsonString = nodeSourceConfigurationParser.wrapPolicyJsonString(submitResult);
-        PluginDescriptor policyPluginDescriptor = nodeSourceConfigurationParser.parseNodeSourceConfiguration(importedNodeSourceJsonString)
-                                                                               .getPolicyPluginDescriptor();
-        this.nodeSourceWindow.setCreatedFromImport();
-        this.nodeSourceWindow.replacePolicyItems(policyPluginDescriptor);
-        this.nodeSourceWindow.resetCreatedFromImport();
+        try {
+            NodeSourceConfigurationParser nodeSourceConfigurationParser = new NodeSourceConfigurationParser();
+            String importedNodeSourceJsonString = nodeSourceConfigurationParser.wrapPolicyJsonString(submitResult);
+            PluginDescriptor policyPluginDescriptor = nodeSourceConfigurationParser.parseNodeSourceConfiguration(importedNodeSourceJsonString)
+                                                                                   .getPolicyPluginDescriptor();
+            this.nodeSourceWindow.setCreatedFromImport();
+            this.nodeSourceWindow.replacePolicyItems(policyPluginDescriptor);
+            this.nodeSourceWindow.resetCreatedFromImport();
+        } catch (Exception e) {
+            this.nodeSourceWindow.setNodeSourceWindowLabelWithError("Import Policy failed", e);
+        }
     }
 
 }


### PR DESCRIPTION
- fix situation where the user could import an infrastructure with a file having a valid policy descriptor. The same could occur for importing a policy inthe infrastructure part. No error would show up as the file format are correct for both.
- the fix is to check whether the policy or infrastructure name exists in the list of retrieved infrastructures and policies from the RM.