### PR TITLE
Fix edit dynamic parameters window of Node Source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -123,6 +123,8 @@ public abstract class NodeSourceWindow {
 
     protected Window window;
 
+    protected DynamicForm nodeSourcePluginsForm;
+
     /**
      * All items of the node source form are held in this map. The key is
      * either the name of the FormItem if there is only one element in the
@@ -130,13 +132,11 @@ public abstract class NodeSourceWindow {
      * by PluginDescriptor#getPluginName. Note that this map must be ordered
      * to achieve a correct display.
      */
-    protected Map<String, List<FormItem>> formItemsByName;
+    private Map<String, List<FormItem>> formItemsByName;
 
     private Label nodeSourceWindowLabel;
 
     private Label nodeSourcePluginsWaitingLabel;
-
-    private DynamicForm nodeSourcePluginsForm;
 
     private String previousSelectedInfrastructure;
 
@@ -474,6 +474,7 @@ public abstract class NodeSourceWindow {
                 LogModel.getInstance().logImportantMessage("Successfully applied '" + actionDescription +
                                                            "' action to Node Source: " + nodeSourceName);
             } else {
+                modifyFormItemsAfterCreation();
                 handleNodeSourceCreationError(nodeSourceWindowLayout, jsonCallback);
             }
             this.nodeSourcePluginsWaitingLabel.hide();
@@ -484,6 +485,7 @@ public abstract class NodeSourceWindow {
             }
         }));
 
+        Arrays.stream(this.nodeSourcePluginsForm.getFields()).forEach(FormItem::enable);
         this.nodeSourcePluginsForm.setCanSubmit(true);
         this.nodeSourcePluginsForm.submitForm();
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
@@ -27,6 +27,7 @@ package org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition;
 
 import static org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.InlineItemModificationCreator.EDIT_FORM_ITEM_SUFFIX;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -96,13 +97,10 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
         List<String> dynamicParametersName = Stream.concat(getDynamicParametersName(focusedInfrastructurePlugin),
                                                            getDynamicParametersName(focusedPolicyPlugin))
                                                    .collect(Collectors.toList());
-
-        for (FormItem formItem : this.nodeSourcePluginsForm.getFields()) {
-            if (isNotDynamic(formItem, dynamicParametersName) &&
-                isFocusedPluginItem(focusedInfrastructurePlugin, focusedPolicyPlugin, formItem)) {
-                formItem.disable();
-            }
-        }
+        Arrays.stream(this.nodeSourcePluginsForm.getFields())
+              .filter(formItem -> isNotDynamic(formItem.getName(), dynamicParametersName) &&
+                                  isFocusedPluginItem(focusedInfrastructurePlugin, focusedPolicyPlugin, formItem))
+              .forEach(FormItem::disable);
     }
 
     private Stream<String> getDynamicParametersName(PluginDescriptor focusedInfrastructurePlugin) {
@@ -119,13 +117,12 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
                formItem.getName().equals(INFRASTRUCTURE_FORM_KEY) || formItem.getName().equals(POLICY_FORM_KEY);
     }
 
-    private boolean isNotDynamic(FormItem formItem, List<String> dynamicParametersName) {
-        return dynamicParametersName.stream().noneMatch(fieldFullName -> isDynamic(formItem, fieldFullName));
+    private boolean isNotDynamic(String formItemName, List<String> dynamicParametersName) {
+        return dynamicParametersName.stream().noneMatch(dynamicItemName -> areEqual(formItemName, dynamicItemName));
     }
 
-    private boolean isDynamic(FormItem formItem, String fieldFullName) {
-        return formItem.getName().equals(fieldFullName) ||
-               formItem.getName().equals(fieldFullName + EDIT_FORM_ITEM_SUFFIX);
+    private boolean areEqual(String formItemName, String otherFormItemName) {
+        return formItemName.equals(otherFormItemName) || formItemName.equals(otherFormItemName + EDIT_FORM_ITEM_SUFFIX);
     }
 
     @Override

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
@@ -27,11 +27,10 @@ package org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition;
 
 import static org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.InlineItemModificationCreator.EDIT_FORM_ITEM_SUFFIX;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.ow2.proactive_grid_cloud_portal.rm.client.NodeSourceConfiguration;
 import org.ow2.proactive_grid_cloud_portal.rm.client.PluginDescriptor;
@@ -39,8 +38,6 @@ import org.ow2.proactive_grid_cloud_portal.rm.client.RMController;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.NodeSourceAction;
 
 import com.smartgwt.client.widgets.form.fields.FormItem;
-import com.smartgwt.client.widgets.form.fields.HiddenItem;
-import com.smartgwt.client.widgets.form.fields.SelectItem;
 import com.smartgwt.client.widgets.form.fields.TextAreaItem;
 import com.smartgwt.client.widgets.layout.HLayout;
 
@@ -80,7 +77,7 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
         this.controller.fetchNodeSourceConfiguration(this.nodeSourceName, () -> {
             NodeSourceConfiguration nodeSourceConfiguration = this.controller.getModel()
                                                                              .getEditedNodeSourceConfiguration();
-            this.nodeSourceNameText.setDefaultValue(nodeSourceConfiguration.getNodeSourceName());
+            this.nodeSourceNameText.setValue(nodeSourceConfiguration.getNodeSourceName());
             this.nodeSourceNameText.disable();
             this.nodesRecoverableCheckbox.setValue(nodeSourceConfiguration.getNodesRecoverable());
             this.nodesRecoverableCheckbox.disable();
@@ -96,56 +93,39 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
     private void disablePluginFormItems(NodeSourceConfiguration nodeSourceConfiguration) {
         PluginDescriptor focusedInfrastructurePlugin = nodeSourceConfiguration.getInfrastructurePluginDescriptor();
         PluginDescriptor focusedPolicyPlugin = nodeSourceConfiguration.getPolicyPluginDescriptor();
+        List<String> dynamicParametersName = Stream.concat(getDynamicParametersName(focusedInfrastructurePlugin),
+                                                           getDynamicParametersName(focusedPolicyPlugin))
+                                                   .collect(Collectors.toList());
 
-        List<String> allDynamicFieldFullNames = focusedInfrastructurePlugin.getConfigurableFields()
-                                                                           .stream()
-                                                                           .filter(PluginDescriptor.Field::isDynamic)
-                                                                           .map(field -> focusedInfrastructurePlugin.getPluginName() +
-                                                                                         field.getName())
-                                                                           .collect(Collectors.toList());
-        allDynamicFieldFullNames.addAll(focusedPolicyPlugin.getConfigurableFields()
-                                                           .stream()
-                                                           .filter(PluginDescriptor.Field::isDynamic)
-                                                           .map(field -> focusedPolicyPlugin.getPluginName() +
-                                                                         field.getName())
-                                                           .collect(Collectors.toList()));
-
-        for (FormItem formItem : this.formItemsByName.values()
-                                                     .stream()
-                                                     .flatMap(Collection::stream)
-                                                     .collect(Collectors.toList())) {
-            if (allDynamicFieldFullNames.stream()
-                                        .noneMatch(fieldFullName -> isItemEqualToDynamicField(formItem,
-                                                                                              fieldFullName))) {
-                filterAndDisableNonDynamicItem(formItem);
+        for (FormItem formItem : this.nodeSourcePluginsForm.getFields()) {
+            if (isNotDynamic(formItem, dynamicParametersName) &&
+                isFocusedPluginItem(focusedInfrastructurePlugin, focusedPolicyPlugin, formItem)) {
+                formItem.disable();
             }
         }
     }
 
-    private boolean isItemEqualToDynamicField(FormItem formItem, String fieldFullName) {
+    private Stream<String> getDynamicParametersName(PluginDescriptor focusedInfrastructurePlugin) {
+        return focusedInfrastructurePlugin.getConfigurableFields()
+                                          .stream()
+                                          .filter(PluginDescriptor.Field::isDynamic)
+                                          .map(field -> focusedInfrastructurePlugin.getPluginName() + field.getName());
+    }
+
+    private boolean isFocusedPluginItem(PluginDescriptor focusedInfrastructurePlugin,
+            PluginDescriptor focusedPolicyPlugin, FormItem formItem) {
+        return formItem.getName().startsWith(focusedInfrastructurePlugin.getPluginName()) ||
+               formItem.getName().startsWith(focusedPolicyPlugin.getPluginName()) ||
+               formItem.getName().equals(INFRASTRUCTURE_FORM_KEY) || formItem.getName().equals(POLICY_FORM_KEY);
+    }
+
+    private boolean isNotDynamic(FormItem formItem, List<String> dynamicParametersName) {
+        return dynamicParametersName.stream().noneMatch(fieldFullName -> isDynamic(formItem, fieldFullName));
+    }
+
+    private boolean isDynamic(FormItem formItem, String fieldFullName) {
         return formItem.getName().equals(fieldFullName) ||
                formItem.getName().equals(fieldFullName + EDIT_FORM_ITEM_SUFFIX);
-    }
-
-    private void filterAndDisableNonDynamicItem(FormItem formItem) {
-        if (this.formItemsByName.keySet().stream().anyMatch(pluginName -> formItem.getName().startsWith(pluginName)) ||
-            formItem.getName().equals(INFRASTRUCTURE_FORM_KEY) || formItem.getName().equals(POLICY_FORM_KEY)) {
-            disableNonDynamicItem(formItem);
-        }
-    }
-
-    private void disableNonDynamicItem(FormItem formItem) {
-        formItem.disable();
-        // when a form item is disabled, it will not be given as parameter of
-        // the submitted form, so we need to add the item content in a hidden
-        // item for it to be submitted with the form. This is true for all
-        // form items but the SelectItem (they are submitted as part of the
-        // form even if disabled), this is why we make a special case.
-        if (!(formItem instanceof SelectItem)) {
-            HiddenItem hiddenItem = new HiddenItem(formItem.getName());
-            hiddenItem.setValue(formItem.getValue());
-            this.formItemsByName.put(formItem.getName(), Collections.singletonList(hiddenItem));
-        }
     }
 
     @Override


### PR DESCRIPTION
- the refactoring in commit a6e6c2e205ed1c3211938e90cc1a90b132d4824d broke the possibility to update dynamic parameters: the parameters that are not dynamic were not passed anymore when the form was submitted.
- the fix consists in disabling the form items that are not dynamic and to re-enable all of them when the form is submitted. This way we do not need anymore to add hidden items to ensure that disabled item are still submitted (simplication of the existing algorithm). The items are disabled again in case the form has an error and the window shows up again after submission.