### PR TITLE
Fix new credentials passing for import/edit node source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -154,14 +154,35 @@ public abstract class NodeSourceWindow {
         this.formItemsByName = new LinkedHashMap<>();
     }
 
+    /**
+     * Implementations must identify their purpose
+     */
     protected abstract NodeSourceAction getNodeSourceAction();
 
+    /**
+     * Implementations must define what to do when fields that are not text
+     * are added to the form
+     */
     protected abstract List<FormItem> handleNonTextualPluginField(PluginDescriptor plugin,
             PluginDescriptor.Field pluginField);
 
-    protected abstract void modifyFormItemsAfterCreation();
+    /**
+     * Implementations can rework the form items after they have been created
+     * through this method
+     */
+    protected abstract void afterItemsCreation();
 
+    /*
+     * Implementations can choose which buttons to add to the form through
+     * this method
+     */
     protected abstract void addButtonsToButtonsLayout(HLayout buttonsLayout);
+
+    /*
+     * Implementations can define something to do before the form is submitted
+     * through this method
+     */
+    protected abstract void beforeSubmit();
 
     protected void buildForm() {
         VLayout nodeSourceWindowLayout = new VLayout();
@@ -313,7 +334,7 @@ public abstract class NodeSourceWindow {
             this.infrastructureSelectItem.addChangedHandler(changedEvent -> resetFormForInfrastructureSelectChange());
             this.policySelectItem.addChangedHandler(changedEvent -> resetFormForPolicySelectChange());
 
-            modifyFormItemsAfterCreation();
+            afterItemsCreation();
 
             this.nodeSourcePluginsForm.setFields(this.formItemsByName.values()
                                                                      .stream()
@@ -474,7 +495,7 @@ public abstract class NodeSourceWindow {
                 LogModel.getInstance().logImportantMessage("Successfully applied '" + actionDescription +
                                                            "' action to Node Source: " + nodeSourceName);
             } else {
-                modifyFormItemsAfterCreation();
+                afterItemsCreation();
                 handleNodeSourceCreationError(nodeSourceWindowLayout, jsonCallback);
             }
             this.nodeSourcePluginsWaitingLabel.hide();
@@ -485,7 +506,7 @@ public abstract class NodeSourceWindow {
             }
         }));
 
-        Arrays.stream(this.nodeSourcePluginsForm.getFields()).forEach(FormItem::enable);
+        beforeSubmit();
         this.nodeSourcePluginsForm.setCanSubmit(true);
         this.nodeSourcePluginsForm.submitForm();
 
@@ -524,7 +545,7 @@ public abstract class NodeSourceWindow {
             this.nodeSourceNameText.setValue(nodeSourceConfiguration.getNodeSourceName());
             this.nodesRecoverableCheckbox.setValue(nodeSourceConfiguration.getNodesRecoverable());
             fillPluginFormItems(nodeSourceConfiguration);
-            modifyFormItemsAfterCreation();
+            afterItemsCreation();
         } catch (Exception e) {
             setNodeSourceWindowLabelWithError("Failed to import Node Source", e);
         }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/creation/CreateNodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/creation/CreateNodeSourceWindow.java
@@ -71,13 +71,18 @@ public class CreateNodeSourceWindow extends NodeSourceWindow {
     }
 
     @Override
-    protected void modifyFormItemsAfterCreation() {
+    protected void afterItemsCreation() {
         // do nothing
     }
 
     @Override
     protected void addButtonsToButtonsLayout(HLayout buttonsLayout) {
         buttonsLayout.setMembers(this.deployNowButton, this.saveAndKeepUndeployedButton, this.cancelButton);
+    }
+
+    @Override
+    protected void beforeSubmit() {
+        // nothing to do
     }
 
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
@@ -69,12 +69,12 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
             PluginDescriptor.Field pluginField) {
         TextAreaItem itemWithFileContent = new TextAreaItem(plugin.getPluginName() + pluginField.getName() +
                                                             EDIT_FORM_ITEM_SUFFIX, pluginField.getName());
-        itemWithFileContent.setDefaultValue(pluginField.getValue());
+        itemWithFileContent.setValue(pluginField.getValue());
         return itemWithFileContent;
     }
 
     @Override
-    protected void modifyFormItemsAfterCreation() {
+    protected void afterItemsCreation() {
         this.controller.fetchNodeSourceConfiguration(this.nodeSourceName, () -> {
             NodeSourceConfiguration nodeSourceConfiguration = this.controller.getModel()
                                                                              .getEditedNodeSourceConfiguration();
@@ -128,6 +128,14 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
     @Override
     protected void addButtonsToButtonsLayout(HLayout buttonsLayout) {
         buttonsLayout.setMembers(this.applyModificationsButton, this.cancelButton);
+    }
+
+    @Override
+    protected void beforeSubmit() {
+        // All disabled items (that the user cannot modify) need to be
+        // re-enabled before being submitted, otherwise they won't be part of
+        // the form data
+        Arrays.stream(this.nodeSourcePluginsForm.getFields()).forEach(FormItem::enable);
     }
 
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
@@ -77,7 +77,7 @@ public class EditNodeSourceWindow extends NodeSourceWindow {
     }
 
     @Override
-    protected void modifyFormItemsAfterCreation() {
+    protected void afterItemsCreation() {
         this.controller.fetchNodeSourceConfiguration(this.nodeSourceName, () -> {
             NodeSourceConfiguration nodeSourceConfiguration = this.controller.getModel()
                                                                              .getEditedNodeSourceConfiguration();
@@ -91,6 +91,11 @@ public class EditNodeSourceWindow extends NodeSourceWindow {
     @Override
     protected void addButtonsToButtonsLayout(HLayout buttonsLayout) {
         buttonsLayout.setMembers(this.deployNowButton, this.saveAndKeepUndeployedButton, this.cancelButton);
+    }
+
+    @Override
+    protected void beforeSubmit() {
+        // nothing to do
     }
 
 }


### PR DESCRIPTION
- in commit e9d3899, a refactoring broke the two options offered when a non-textual field was edited. Only the inline editing was taken into account when submitting the form, even when new credentials were uploaded. This was because all items were re-enabled before being submitted, so the inline item was taking over the new file item. Re-enabling of items is only useful for dynamic node source edition, so this code has been moved in EditDynamicParametersWindow only. In this class, we do not have the problem of two-options items because non-textual items can only be viewed.