### PR TITLE
Handle Ctrl-A select all

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/JobsView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/JobsView.java
@@ -36,6 +36,8 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.shared.filter.FilterModel;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.smartgwt.client.widgets.Label;
+import com.smartgwt.client.widgets.events.KeyPressEvent;
+import com.smartgwt.client.widgets.events.KeyPressHandler;
 import com.smartgwt.client.widgets.layout.Layout;
 
 
@@ -85,6 +87,15 @@ public class JobsView extends FilteringGridItemView<Job> implements JobsUpdatedL
     @Override
     protected void buildGrid() {
         this.itemsGrid = new JobsListGrid(this.controller);
+        this.itemsGrid.addKeyPressHandler(new KeyPressHandler() {
+            @Override
+            public void onKeyPress(KeyPressEvent event) {
+                if (event.getKeyName().toLowerCase().equals("a") && event.isCtrlKeyDown()) {
+                    event.cancel();
+                    itemsGrid.selectAllRecords();
+                }
+            }
+        });
         this.itemsGrid.build();
     }
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/TasksCentricView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/TasksCentricView.java
@@ -37,6 +37,8 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.Task
 import com.google.gwt.user.client.ui.Widget;
 import com.smartgwt.client.types.TopOperatorAppearance;
 import com.smartgwt.client.widgets.Label;
+import com.smartgwt.client.widgets.events.KeyPressEvent;
+import com.smartgwt.client.widgets.events.KeyPressHandler;
 import com.smartgwt.client.widgets.form.FilterBuilder;
 import com.smartgwt.client.widgets.layout.Layout;
 
@@ -87,6 +89,15 @@ public class TasksCentricView extends FilteringGridItemView<Task> implements Tas
     protected void buildGrid() {
         TasksCentricColumnsFactory factory = new TasksCentricColumnsFactory();
         this.itemsGrid = new TasksListGrid(this.controller, factory, "tasksCentricDS_", true);
+        this.itemsGrid.addKeyPressHandler(new KeyPressHandler() {
+            @Override
+            public void onKeyPress(KeyPressEvent event) {
+                if (event.getKeyName().toLowerCase().equals("a") && event.isCtrlKeyDown()) {
+                    event.cancel();
+                    itemsGrid.selectAllRecords();
+                }
+            }
+        });
         this.itemsGrid.build();
     }
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/TasksView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/TasksView.java
@@ -35,6 +35,8 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.Expa
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.ExpandableTasksColumnsFactory;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.ExpandableTasksListGrid;
 
+import com.smartgwt.client.widgets.events.KeyPressEvent;
+import com.smartgwt.client.widgets.events.KeyPressHandler;
 import com.smartgwt.client.widgets.layout.Layout;
 
 
@@ -79,6 +81,15 @@ public class TasksView extends AbstractGridItemsView<Task> implements TasksUpdat
         ExpandableTasksColumnsFactory expandableFactory = new ExpandableTasksColumnsFactory();
         ExpandTasksColumnsFactory expandFactory = new ExpandTasksColumnsFactory();
         this.itemsGrid = new ExpandableTasksListGrid(this.controller, expandableFactory, expandFactory, "tasksDS_");
+        this.itemsGrid.addKeyPressHandler(new KeyPressHandler() {
+            @Override
+            public void onKeyPress(KeyPressEvent event) {
+                if (event.getKeyName().toLowerCase().equals("a") && event.isCtrlKeyDown()) {
+                    event.cancel();
+                    itemsGrid.selectAllRecords();
+                }
+            }
+        });
         this.itemsGrid.build();
     }
 


### PR DESCRIPTION
 - using Ctrl-A users can select all jobs, provided they first have selected one item in the list
 - same applies for tasks and task-centric view, though these are sensible to the refresh period in the contrary to jobs