### PR TITLE
fix regression on selected job(s)

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsPaginationModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsPaginationModel.java
@@ -162,7 +162,7 @@ public class JobsPaginationModel extends PaginationModel {
 
     public void setHasPreviousPage(boolean hasPreviousPage) {
         this.hasPreviousPage = hasPreviousPage;
-        doActionOnListeners(listener -> listener.pageChanged());
+        doActionOnListeners(listener -> listener.totalItemChanged());
     }
 
     public boolean hasNextPage() {
@@ -171,7 +171,7 @@ public class JobsPaginationModel extends PaginationModel {
 
     public void setHasNextPage(boolean hasNextPage) {
         this.hasNextPage = hasNextPage;
-        doActionOnListeners(listener -> listener.pageChanged());
+        doActionOnListeners(listener -> listener.totalItemChanged());
     }
 
     public boolean isFirst() {


### PR DESCRIPTION
latest commit introduced a regression where jobs became unselected on each job list update.
This is because calling the pageChanged event unselects all jobs. Change the event used to appropriate totalItemsChanged.