### PR TITLE
Update navbars to sync with new studio navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ rm-portal/src/main/webapp/portal/
 scheduler-portal/src/main/webapp/WEB-INF/deploy/
 scheduler-portal/src/main/webapp/portal/
 
+common-portal/out/
+scheduler-portal/out/
+
 /lib/
 /.settings/
 /classes/
@@ -18,3 +21,5 @@ gradle/ext/
 *.settings
 applet/bin/
 rm-portal/bin/
+
+*.DS_Store

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
@@ -27,10 +27,7 @@ package org.ow2.proactive_grid_cloud_portal.common.client;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
-import com.smartgwt.client.util.BooleanCallback;
 import com.smartgwt.client.util.SC;
-import com.smartgwt.client.widgets.events.ClickEvent;
-import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 
 
@@ -75,17 +72,11 @@ public class ToolButtonsRender {
         logoutButton.setTooltip("Logout");
         logoutButton.setBorder(GREY_BUTTON_BORDER);
 
-        logoutButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
-                SC.confirm("Logout", "Are you sure you want to exit?", new BooleanCallback() {
-                    public void execute(Boolean value) {
-                        if (value) {
-                            controller.logout();
-                        }
-                    }
-                });
+        logoutButton.addClickHandler(event -> SC.confirm("Logout", "Are you sure you want to exit?", value -> {
+            if (value) {
+                controller.logout();
             }
-        });
+        }));
         return logoutButton;
     }
 
@@ -108,11 +99,7 @@ public class ToolButtonsRender {
             final String url) {
         ToolStripButton toolStripButton = getSimpleToolStripButton(imageResource, title);
 
-        toolStripButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
-                Window.open(url, url, "");
-            }
-        });
+        toolStripButton.addClickHandler(event -> Window.open(url, url, ""));
         return toolStripButton;
     }
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -282,7 +282,6 @@ public class RMPage implements LogListener {
         ToolStripButton resourceManagerLinkButton = toolButtonsRender.getResourceManagerHighlightedLinkButton();
         ToolStripButton logoutButton = toolButtonsRender.getLogoutButton(login, RMPage.this.controller);
 
-
         // Shortcut buttons strip
         ToolStrip paShortcutsStrip = new ToolStrip();
         paShortcutsStrip.addButton(automationDashboardLinkButton);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -51,22 +51,12 @@ import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.Overflow;
 import com.smartgwt.client.types.VerticalAlignment;
 import com.smartgwt.client.types.VisibilityMode;
-import com.smartgwt.client.util.BooleanCallback;
 import com.smartgwt.client.util.SC;
 import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.Img;
 import com.smartgwt.client.widgets.ImgButton;
-import com.smartgwt.client.widgets.Label;
-import com.smartgwt.client.widgets.events.ClickEvent;
-import com.smartgwt.client.widgets.events.ClickHandler;
-import com.smartgwt.client.widgets.events.DrawEvent;
-import com.smartgwt.client.widgets.events.DrawHandler;
-import com.smartgwt.client.widgets.events.ResizedEvent;
-import com.smartgwt.client.widgets.events.ResizedHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.form.fields.CheckboxItem;
-import com.smartgwt.client.widgets.form.fields.events.ChangedEvent;
-import com.smartgwt.client.widgets.form.fields.events.ChangedHandler;
 import com.smartgwt.client.widgets.layout.HLayout;
 import com.smartgwt.client.widgets.layout.LayoutSpacer;
 import com.smartgwt.client.widgets.layout.SectionStack;
@@ -75,19 +65,16 @@ import com.smartgwt.client.widgets.layout.VLayout;
 import com.smartgwt.client.widgets.menu.Menu;
 import com.smartgwt.client.widgets.menu.MenuItem;
 import com.smartgwt.client.widgets.menu.MenuItemSeparator;
-import com.smartgwt.client.widgets.menu.events.MenuItemClickEvent;
 import com.smartgwt.client.widgets.tab.Tab;
 import com.smartgwt.client.widgets.tab.TabSet;
 import com.smartgwt.client.widgets.toolbar.ToolStrip;
 import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 import com.smartgwt.client.widgets.toolbar.ToolStripMenuButton;
+import com.smartgwt.client.widgets.toolbar.ToolStripSeparator;
 
 
 /**
  * Page shown when an user is logged
- * 
- * 
- * 
  * 
  * @author mschnoor
  *
@@ -149,7 +136,7 @@ public class RMPage implements LogListener {
     // Logo strip properties
     private int logoStripHeight = 40;
 
-    private String logoStripBackgroundColor = "#fafafa";
+    private static final String LOGO_STRIP_BACKGROUND_COLOR = "#fafafa";
 
     private String logoStripBorder = "0px";
 
@@ -167,7 +154,7 @@ public class RMPage implements LogListener {
         this.rootLayout = rl;
         rl.setWidth100();
         rl.setHeight100();
-        rl.setBackgroundColor("#fafafa");
+        rl.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
 
         this.aboutWindow = new AboutWindow();
         this.addNodeWindow = new AddNodeWindow();
@@ -198,11 +185,7 @@ public class RMPage implements LogListener {
         expandButton.setHeight(16);
         expandButton.setSrc(Images.instance.expand_16().getSafeUri().asString());
         expandButton.setTooltip("Expand all items");
-        expandButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
-                RMPage.this.treeView.expandAll();
-            }
-        });
+        expandButton.addClickHandler(event -> RMPage.this.treeView.expandAll());
         expandButton.setShowFocusedIcon(false);
         expandButton.setShowRollOver(false);
         expandButton.setShowDown(false);
@@ -210,11 +193,7 @@ public class RMPage implements LogListener {
 
         final CheckboxItem c1 = new CheckboxItem("mynodes", "My nodes");
         c1.setValue(false);
-        c1.addChangedHandler(new ChangedHandler() {
-            public void onChanged(ChangedEvent event) {
-                compactView.setViewMyNodes(c1.getValueAsBoolean());
-            }
-        });
+        c1.addChangedHandler(event -> compactView.setViewMyNodes(c1.getValueAsBoolean()));
 
         // for some reason IE9 standards fails to detect the right width
         if (SC.isIE()) {
@@ -230,11 +209,7 @@ public class RMPage implements LogListener {
         closeButton.setHeight(16);
         closeButton.setSrc(Images.instance.close_16().getSafeUri().asString());
         closeButton.setTooltip("Collapse all items");
-        closeButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
-                RMPage.this.treeView.closeAll();
-            }
-        });
+        closeButton.addClickHandler(event -> RMPage.this.treeView.closeAll());
         closeButton.setShowFocusedIcon(false);
         closeButton.setShowRollOver(false);
         closeButton.setShowDown(false);
@@ -264,18 +239,8 @@ public class RMPage implements LogListener {
         stack.setSections(topSection, botSection);
 
         // dynamic width of controls layout
-        stack.addResizedHandler(new ResizedHandler() {
-            @Override
-            public void onResized(ResizedEvent event) {
-                controls.setWidth(stack.getWidth() - EXPAND_COLLAPSE_SECTION_LABEL_WIDTH);
-            }
-        });
-        stack.addDrawHandler(new DrawHandler() {
-            @Override
-            public void onDraw(DrawEvent event) {
-                controls.setWidth(stack.getWidth() - EXPAND_COLLAPSE_SECTION_LABEL_WIDTH);
-            }
-        });
+        stack.addResizedHandler(event -> controls.setWidth(stack.getWidth() - EXPAND_COLLAPSE_SECTION_LABEL_WIDTH));
+        stack.addDrawHandler(event -> controls.setWidth(stack.getWidth() - EXPAND_COLLAPSE_SECTION_LABEL_WIDTH));
 
         rl.addMember(buildLogoStrip());
         rl.addMember(header);
@@ -288,61 +253,73 @@ public class RMPage implements LogListener {
     }
 
     private ToolStrip buildLogoStrip() {
-        final Label resourcesLabel = new Label("ProActive Resource Manager");
-        resourcesLabel.setStyleName("rmHeadline");
-        resourcesLabel.setHeight100();
-        resourcesLabel.setAutoWidth();
 
-        ToolStrip logoPA = new ToolStrip();
-        logoPA.setHeight(logoStripHeight);
-        logoPA.setWidth("33%");
-        logoPA.setBackgroundImage("");
-        logoPA.setBackgroundColor(logoStripBackgroundColor);
-        logoPA.setMargin(0);
-        logoPA.setBorder(logoStripBorder);
-        logoPA.setAlign(Alignment.LEFT);
-        logoPA.addMember(new Img(RMImagesUnbundled.PA_ICON, logoStripHeight, logoStripHeight));
-        logoPA.addMember(resourcesLabel);
-
-        ToolStrip additionalLogoCenter = new ToolStrip();
-        additionalLogoCenter.setHeight(logoStripHeight);
-        additionalLogoCenter.setWidth("33%");
-        additionalLogoCenter.setBackgroundImage("");
-        additionalLogoCenter.setBackgroundColor(logoStripBackgroundColor);
-        additionalLogoCenter.setMargin(0);
-        additionalLogoCenter.setBorder(logoStripBorder);
-        additionalLogoCenter.setAlign(Alignment.CENTER);
-        Img logoAzureImg = new Img(RMImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
-        additionalLogoCenter.addMember(logoAzureImg);
-
+        // Activeeon Logo
         ToolStrip logoAE = new ToolStrip();
         logoAE.setHeight(logoStripHeight);
         logoAE.setWidth("33%");
         logoAE.setBackgroundImage("");
-        logoAE.setBackgroundColor(logoStripBackgroundColor);
+        logoAE.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
         logoAE.setMargin(0);
         logoAE.setBorder(logoStripBorder);
-        logoAE.setAlign(Alignment.RIGHT);
+        logoAE.setAlign(Alignment.LEFT);
+        logoAE.setStyleName("brand-logo");
+        logoAE.setTop(0);
         Img logoImg = new Img(RMImagesUnbundled.AE_LOGO, 146, logoStripHeight);
-        logoImg.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-                Window.open("http://activeeon.com/", "", "");
-            }
-        });
+        logoImg.addClickHandler(clickEvent -> Window.open("http://activeeon.com/", "", ""));
         logoAE.addMember(logoImg);
 
+        String login = LoginModel.getInstance().getLogin();
+        if (login != null) {
+            login = " <b>" + login + "</b>";
+        } else {
+            login = "";
+        }
+
+        ToolStripButton automationDashboardLinkButton = toolButtonsRender.getAutomationDashboardLinkButton();
+        ToolStripButton studioLinkButton = toolButtonsRender.getStudioLinkButton();
+        ToolStripButton schedulerLinkButton = toolButtonsRender.getSchedulerLinkButton();
+        ToolStripButton resourceManagerLinkButton = toolButtonsRender.getResourceManagerHighlightedLinkButton();
+        ToolStripButton logoutButton = toolButtonsRender.getLogoutButton(login, RMPage.this.controller);
+
+
+        // Shortcut buttons strip
+        ToolStrip paShortcutsStrip = new ToolStrip();
+        paShortcutsStrip.addButton(automationDashboardLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(studioLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(schedulerLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(resourceManagerLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        ToolStripSeparator separator = new ToolStripSeparator();
+        separator.setHeight(40);
+        paShortcutsStrip.addMember(separator);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(logoutButton);
+        paShortcutsStrip.addSpacer(4);
+
+        paShortcutsStrip.setMargin(5);
+        paShortcutsStrip.setBackgroundImage("");
+        paShortcutsStrip.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
+        paShortcutsStrip.setBorder(logoStripBorder);
+        paShortcutsStrip.setAlign(Alignment.RIGHT);
+        paShortcutsStrip.setStyleName("pa-shortcuts");
+        paShortcutsStrip.setPosition("static");
+        paShortcutsStrip.setAlign(Alignment.RIGHT);
+
+        // Navbar Header
         ToolStrip logoStrip = new ToolStrip();
-        logoStrip.setStyleName("paddingLeftAndRight");
         logoStrip.setHeight(logoStripHeight);
         logoStrip.setWidth100();
         logoStrip.setBackgroundImage("");
-        logoStrip.setBackgroundColor(logoStripBackgroundColor);
+        logoStrip.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
         logoStrip.setBorder(logoStripBorder);
         logoStrip.setMargin(0);
-        logoStrip.addMember(logoPA);
-        logoStrip.addMember(additionalLogoCenter);
+
         logoStrip.addMember(logoAE);
+        logoStrip.addMember(paShortcutsStrip);
 
         return logoStrip;
     }
@@ -352,43 +329,24 @@ public class RMPage implements LogListener {
         tools.setHeight(50);
         tools.setWidth100();
         tools.setBackgroundImage("");
-        tools.setBackgroundColor("#fafafa");
+        tools.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
         tools.setBorder("0px");
 
         MenuItem settingsMenuItem = new MenuItem("Settings", Images.instance.settings_16().getSafeUri().asString());
-        settingsMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                RMPage.this.settingsWindow.show();
-            }
-        });
+        settingsMenuItem.addClickHandler(event -> RMPage.this.settingsWindow.show());
 
         MenuItem credMenuItem = new MenuItem("Create credentials", Images.instance.key_16().getSafeUri().asString());
-        credMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                RMPage.this.credentialsWindow.show();
-            }
-        });
+        credMenuItem.addClickHandler(event -> RMPage.this.credentialsWindow.show());
 
         MenuItem nodeMenuItem = new MenuItem("Launch a Node", ImagesUnbundled.PA_16);
-        nodeMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                RMPage.this.addNodeWindow.show();
-                //Window.open(RMConfig.get().getRestUrl() + "/../node.jar", "", "");
-            }
-        });
+        nodeMenuItem.addClickHandler(event -> RMPage.this.addNodeWindow.show());
 
         MenuItem logoutMenuItem = new MenuItem("Logout", Images.instance.exit_18().getSafeUri().asString());
-        logoutMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                SC.confirm("Logout", "Are you sure you want to exit?", new BooleanCallback() {
-                    public void execute(Boolean value) {
-                        if (value) {
-                            RMPage.this.controller.logout();
-                        }
-                    }
-                });
+        logoutMenuItem.addClickHandler(event -> SC.confirm("Logout", "Are you sure you want to exit?", value -> {
+            if (value) {
+                RMPage.this.controller.logout();
             }
-        });
+        }));
 
         ToolStripMenuButton portalMenuButton = new ToolStripMenuButton("Portal");
         Menu portalMenu = new Menu();
@@ -400,29 +358,17 @@ public class RMPage implements LogListener {
 
         MenuItem documentationMenuItem = new MenuItem("Documentation",
                                                       Images.instance.icon_manual().getSafeUri().asString());
-        documentationMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "dev" : Config.get().getVersion();
-                Window.open("http://doc.activeeon.com/" + docVersion, "", "");
-            }
+        documentationMenuItem.addClickHandler(event -> {
+            String docVersion = Config.get().getVersion().contains("SNAPSHOT") ? "dev" : Config.get().getVersion();
+            Window.open("http://doc.activeeon.com/" + docVersion, "", "");
         });
 
         MenuItem aboutMenuItem = new MenuItem("About", Images.instance.about_16().getSafeUri().asString());
-        aboutMenuItem.addClickHandler(new com.smartgwt.client.widgets.menu.events.ClickHandler() {
-            public void onClick(MenuItemClickEvent event) {
-                RMPage.this.aboutWindow.show();
-            }
-        });
+        aboutMenuItem.addClickHandler(event -> RMPage.this.aboutWindow.show());
         ToolStripMenuButton helpMenuButton = new ToolStripMenuButton("Help");
         Menu helpMenu = new Menu();
         helpMenu.setItems(logMenuItem, documentationMenuItem, aboutMenuItem);
         helpMenuButton.setMenu(helpMenu);
-
-        String login = LoginModel.getInstance().getLogin();
-        if (login != null)
-            login = " <b>" + login + "</b>";
-        else
-            login = "";
 
         ToolStripButton nsButton = new ToolStripButton("Add Node Source");
         nsButton.setIcon(RMImages.instance.nodesource_deployed().getSafeUri().asString());
@@ -435,11 +381,16 @@ public class RMPage implements LogListener {
         errorButton.addClickHandler(e -> showLogWindow());
         errorButton.hide();
 
-        ToolStripButton studioLinkButton = toolButtonsRender.getStudioLinkButton();
-        ToolStripButton schedulerLinkButton = toolButtonsRender.getSchedulerLinkButton();
-        ToolStripButton automationDashboardLinkButton = toolButtonsRender.getAutomationDashboardLinkButton();
-        ToolStripButton resourceManagerLinkButton = toolButtonsRender.getResourceManagerHighlightedLinkButton();
-        ToolStripButton logoutButton = toolButtonsRender.getLogoutButton(login, RMPage.this.controller);
+        ToolStrip additionalLogoCenter = new ToolStrip();
+        additionalLogoCenter.setHeight(logoStripHeight);
+        additionalLogoCenter.setWidth("10%");
+        additionalLogoCenter.setBackgroundImage("");
+        additionalLogoCenter.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
+        additionalLogoCenter.setMargin(0);
+        additionalLogoCenter.setBorder(logoStripBorder);
+        additionalLogoCenter.setAlign(Alignment.CENTER);
+        Img logoAzureImg = new Img(RMImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
+        additionalLogoCenter.addMember(logoAzureImg);
 
         tools.addMenuButton(portalMenuButton);
         tools.addMenuButton(helpMenuButton);
@@ -447,18 +398,7 @@ public class RMPage implements LogListener {
         tools.addButton(nsButton);
         tools.addButton(errorButton);
         tools.addFill();
-        tools.addButton(automationDashboardLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(studioLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(schedulerLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(resourceManagerLinkButton);
-        tools.addSpacer(2);
-        tools.addSeparator();
-        tools.addSpacer(2);
-        tools.addButton(logoutButton);
-        tools.addSpacer(10);
+        tools.addMember(additionalLogoCenter);
 
         return tools;
     }
@@ -555,10 +495,7 @@ public class RMPage implements LogListener {
 
     @Override
     public void logImportantMessage(String message) {
-        long dt = System.currentTimeMillis() - this.lastCriticalMessage;
-        if (dt > RMConfig.get().getClientRefreshTime() * 4) {
-            this.errorButton.hide();
-        }
+        logMessage(message);
     }
 
     @Override

--- a/rm-portal/src/main/webapp/portal.css
+++ b/rm-portal/src/main/webapp/portal.css
@@ -22,7 +22,50 @@
 .paddingLeftAndRight {
 	padding-left: 10px;
 	padding-right: 10px;
+}
 
+.brand-logo{
+	padding-left: 6px;
+	padding-right: 6px;
+	top: 0px!important;
+}
+
+.pa-shortcuts > div {
+	position:static!important;
+	display: -webkit-inline-flex!important;;
+	display: -ms-inline-flexbox!important;;
+	display: -moz-flex!important;;
+	display: inline-flex!important;
+}
+
+.pa-shortcuts > div > div {
+	overflow-x: hidden;
+	transition: width 300ms;
+	transition-timing-function: ease;
+	-webkit-transition: width 300ms;
+	-webkit-transition-timing-function: ease;
+	margin-left: 4px!important;
+	position: static!important;
+}
+
+.pa-shortcuts > .active {
+	background-color: #f76800;
+	color: white;
+}
+
+.pa-shortcuts {
+	padding-left: 0px!important;
+	padding-right: 0px!important;
+	transition: width 500ms;
+	transition-timing-function: ease;
+	-webkit-transition: width 500ms;
+	-webkit-transition-timing-function: ease;
+	display: -webkit-inline-flex;
+	display: -ms-inline-flexbox;
+	display: -moz-flex;
+	display: inline-flex;
+	float: right;
+	width: auto!important;
 }
 
 .toolStripButton, .toolStripButtonOver, .toolStripButtonFocused, .toolStripButtonFocusedOver, .toolStripButtonDown, .toolStripButtonFocusedDown, .toolStripButtonSelected, .toolStripButtonSelectedFocused, .toolStripButtonSelectedDown, .toolStripButtonSelectedFocusedDown, .toolStripButtonSelectedOver, .toolStripButtonSelectedFocusedOver, .toolStripButtonDisabled, .toolStripButtonSelectedDisabled {

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
@@ -77,6 +77,7 @@ import com.smartgwt.client.widgets.tab.TabSet;
 import com.smartgwt.client.widgets.toolbar.ToolStrip;
 import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 import com.smartgwt.client.widgets.toolbar.ToolStripMenuButton;
+import com.smartgwt.client.widgets.toolbar.ToolStripSeparator;
 
 
 /**
@@ -121,19 +122,19 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
     /* Actions descriptions */
     private static final String DESCRIPTION = "description";
 
-    private static final String schedStartButtonDescription = "Start Scheduler Server from Stopped status";
+    private static final String SCHED_START_BUTTON_DESCRIPTION = "Start Scheduler Server from Stopped status";
 
-    private static final String schedStopButtonDescription = "Stop Scheduler Server (Submitted Jobs terminate)";
+    private static final String SCHED_STOP_BUTTON_DESCRIPTION = "Stop Scheduler Server (Submitted Jobs terminate)";
 
-    private static final String schedFreezeButtonDescription = "Freeze Scheduler Server (Running Tasks terminate)";
+    private static final String SCHED_FREEZE_BUTTON_DESCRIPTION = "Freeze Scheduler Server (Running Tasks terminate)";
 
-    private static final String schedResumeButtonDescription = "Resume Scheduler Server from Paused or Frozen status";
+    private static final String SCHED_RESUME_BUTTON_DESCRIPTION = "Resume Scheduler Server from Paused or Frozen status";
 
-    private static final String schedPauseButtonDescription = "Pause Scheduler Server (Running Jobs terminate)";
+    private static final String SCHED_PAUSE_BUTTON_DESCRIPTION = "Pause Scheduler Server (Running Jobs terminate)";
 
-    private static final String schedKillButtonDescription = "Kill Scheduler Server";
+    private static final String SCHED_KILL_BUTTON_DESCRIPTION = "Kill Scheduler Server";
 
-    private static final String schedShutdownButtonDescription = "Shutdown Scheduler Server (Running Tasks terminate)";
+    private static final String SCHED_SHUTDOWN_BUTTON_DESCRIPTION = "Shutdown Scheduler Server (Running Tasks terminate)";
 
     /** root layout: parent to all widgets of this view */
     private Layout rootLayout = null;
@@ -270,37 +271,23 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
     }
 
     /** admin scheduler functionalities */
-    private MenuItem schedStartButton, schedStopButton, schedFreezeButton, schedResumeButton, schedPauseButton,
-            schedKillButton, schedShutdownButton;
+    private MenuItem schedStartButton;
+
+    private MenuItem schedStopButton;
+
+    private MenuItem schedFreezeButton;
+
+    private MenuItem schedResumeButton;
+
+    private MenuItem schedPauseButton;
+
+    private MenuItem schedKillButton;
+
+    private MenuItem schedShutdownButton;
 
     private ToolStrip buildLogoStrip() {
-        final Label schedulerLabel = new Label("ProActive Scheduling & Orchestration");
-        schedulerLabel.setStyleName("schedulerHeadline");
-        schedulerLabel.setHeight100();
-        schedulerLabel.setAutoWidth();
 
-        ToolStrip logoPA = new ToolStrip();
-        logoPA.setHeight(logoStripHeight);
-        logoPA.setWidth("33%");
-        logoPA.setBackgroundImage("");
-        logoPA.setBackgroundColor(logoStripBackgroundColor);
-        logoPA.setMargin(0);
-        logoPA.setBorder(logoStripBorder);
-        logoPA.setAlign(Alignment.LEFT);
-        logoPA.addMember(new Img(SchedulerImagesUnbundled.PA_ICON, logoStripHeight, logoStripHeight));
-        logoPA.addMember(schedulerLabel);
-
-        ToolStrip additionalLogoCenter = new ToolStrip();
-        additionalLogoCenter.setHeight(logoStripHeight);
-        additionalLogoCenter.setWidth("33%");
-        additionalLogoCenter.setBackgroundImage("");
-        additionalLogoCenter.setBackgroundColor(logoStripBackgroundColor);
-        additionalLogoCenter.setMargin(0);
-        additionalLogoCenter.setBorder(logoStripBorder);
-        additionalLogoCenter.setAlign(Alignment.CENTER);
-        Img logoAzureImg = new Img(SchedulerImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
-        additionalLogoCenter.addMember(logoAzureImg);
-
+        // Activeeon Logo
         ToolStrip logoAE = new ToolStrip();
         logoAE.setHeight(logoStripHeight);
         logoAE.setWidth("33%");
@@ -308,22 +295,62 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         logoAE.setBackgroundColor(logoStripBackgroundColor);
         logoAE.setMargin(0);
         logoAE.setBorder(logoStripBorder);
-        logoAE.setAlign(Alignment.RIGHT);
+        logoAE.setAlign(Alignment.LEFT);
+        logoAE.setStyleName("brand-logo");
         Img logoImg = new Img(SchedulerImagesUnbundled.AE_LOGO, 146, logoStripHeight);
         logoImg.addClickHandler(clickEvent -> Window.open("http://activeeon.com/", "", ""));
         logoAE.addMember(logoImg);
 
+        String login = LoginModel.getInstance().getLogin();
+        if (login != null) {
+            login = " <b>" + login + "</b>";
+        } else {
+            login = "";
+        }
+
+        ToolStripButton automationDashboardLinkButton = toolButtonsRender.getAutomationDashboardLinkButton();
+        ToolStripButton studioLinkButton = toolButtonsRender.getStudioLinkButton();
+        ToolStripButton schedulerLinkButton = toolButtonsRender.getSchedulerHighlightedLinkButton();
+        ToolStripButton resourceManagerLinkButton = toolButtonsRender.getResourceManagerLinkButton();
+        ToolStripButton logoutButton = toolButtonsRender.getLogoutButton(login, SchedulerPage.this.controller);
+
+        // Shortcut buttons strip
+        ToolStrip paShortcutsStrip = new ToolStrip();
+        paShortcutsStrip.addButton(automationDashboardLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(studioLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(schedulerLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(resourceManagerLinkButton);
+        paShortcutsStrip.addSpacer(4);
+        ToolStripSeparator separator = new ToolStripSeparator();
+        separator.setHeight(40);
+        paShortcutsStrip.addMember(separator);
+        paShortcutsStrip.addSpacer(4);
+        paShortcutsStrip.addButton(logoutButton);
+        paShortcutsStrip.addSpacer(4);
+
+        paShortcutsStrip.setMargin(5);
+        paShortcutsStrip.setBackgroundImage("");
+        paShortcutsStrip.setBackgroundColor(logoStripBackgroundColor);
+        paShortcutsStrip.setBorder(logoStripBorder);
+        paShortcutsStrip.setAlign(Alignment.RIGHT);
+        paShortcutsStrip.setStyleName("pa-shortcuts");
+        paShortcutsStrip.setPosition("static");
+        paShortcutsStrip.setAlign(Alignment.RIGHT);
+
+        // Navbar Header
         ToolStrip logoStrip = new ToolStrip();
-        logoStrip.setStyleName("paddingLeftAndRight");
         logoStrip.setHeight(logoStripHeight);
         logoStrip.setWidth100();
         logoStrip.setBackgroundImage("");
         logoStrip.setBackgroundColor(logoStripBackgroundColor);
         logoStrip.setBorder(logoStripBorder);
         logoStrip.setMargin(0);
-        logoStrip.addMember(logoPA);
-        logoStrip.addMember(additionalLogoCenter);
+
         logoStrip.addMember(logoAE);
+        logoStrip.addMember(paShortcutsStrip);
 
         return logoStrip;
     }
@@ -429,32 +456,32 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
 
         schedStartButton = new MenuItem(START);
         schedStartButton.setIcon(SchedulerImages.instance.scheduler_start_16().getSafeUri().asString());
-        schedStartButton.setAttribute(DESCRIPTION, schedStartButtonDescription);
+        schedStartButton.setAttribute(DESCRIPTION, SCHED_START_BUTTON_DESCRIPTION);
         schedStartButton.addClickHandler(event -> SchedulerPage.this.controller.startScheduler());
 
         schedStopButton = new MenuItem(STOP);
         schedStopButton.setIcon(SchedulerImages.instance.scheduler_stop_16().getSafeUri().asString());
-        schedStopButton.setAttribute(DESCRIPTION, schedStopButtonDescription);
+        schedStopButton.setAttribute(DESCRIPTION, SCHED_STOP_BUTTON_DESCRIPTION);
         schedStopButton.addClickHandler(event -> SchedulerPage.this.controller.stopScheduler());
 
         schedFreezeButton = new MenuItem(FREEZE);
         schedFreezeButton.setIcon(SchedulerImages.instance.scheduler_freeze_16().getSafeUri().asString());
-        schedFreezeButton.setAttribute(DESCRIPTION, schedFreezeButtonDescription);
+        schedFreezeButton.setAttribute(DESCRIPTION, SCHED_FREEZE_BUTTON_DESCRIPTION);
         schedFreezeButton.addClickHandler(event -> SchedulerPage.this.controller.freezeScheduler());
 
         schedResumeButton = new MenuItem(RESUME);
         schedResumeButton.setIcon(SchedulerImages.instance.scheduler_resume_16().getSafeUri().asString());
-        schedResumeButton.setAttribute(DESCRIPTION, schedResumeButtonDescription);
+        schedResumeButton.setAttribute(DESCRIPTION, SCHED_RESUME_BUTTON_DESCRIPTION);
         schedResumeButton.addClickHandler(event -> SchedulerPage.this.controller.resumeScheduler());
 
         schedPauseButton = new MenuItem(PAUSE);
         schedPauseButton.setIcon(SchedulerImages.instance.scheduler_pause_16().getSafeUri().asString());
-        schedPauseButton.setAttribute(DESCRIPTION, schedPauseButtonDescription);
+        schedPauseButton.setAttribute(DESCRIPTION, SCHED_PAUSE_BUTTON_DESCRIPTION);
         schedPauseButton.addClickHandler(event -> SchedulerPage.this.controller.pauseScheduler());
 
         schedKillButton = new MenuItem(KILL);
         schedKillButton.setIcon(SchedulerImages.instance.scheduler_kill_16().getSafeUri().asString());
-        schedKillButton.setAttribute(DESCRIPTION, schedKillButtonDescription);
+        schedKillButton.setAttribute(DESCRIPTION, SCHED_KILL_BUTTON_DESCRIPTION);
         schedKillButton.addClickHandler(event -> SC.confirm("Do you really want to <strong>kill</strong> the Scheduler?",
                                                             value -> {
                                                                 if (value)
@@ -463,7 +490,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
 
         schedShutdownButton = new MenuItem(SHUTDOWN);
         schedShutdownButton.setIcon(SchedulerImages.instance.scheduler_shutdown_16().getSafeUri().asString());
-        schedShutdownButton.setAttribute(DESCRIPTION, schedShutdownButtonDescription);
+        schedShutdownButton.setAttribute(DESCRIPTION, SCHED_SHUTDOWN_BUTTON_DESCRIPTION);
         schedShutdownButton.addClickHandler(event -> SC.confirm("Do you really want to <strong>shutdown</strong> the Scheduler?",
                                                                 value -> {
                                                                     if (value)
@@ -493,12 +520,6 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         });
         adminMenuButton.setMenu(adminMenu);
 
-        String login = LoginModel.getInstance().getLogin();
-        if (login != null)
-            login = " <b>" + login + "</b>";
-        else
-            login = "";
-
         errorButton = new ToolStripButton("<strong>Network error</strong>",
                                           Images.instance.net_error_16().getSafeUri().asString());
         errorButton.setBackgroundColor("#ffbbbb");
@@ -515,11 +536,16 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         HLayout schedulerStatusLabelLayout = new HLayout();
         schedulerStatusLabelLayout.addMember(schedulerStatusLabel);
 
-        ToolStripButton resourceManagerLinkButton = toolButtonsRender.getResourceManagerLinkButton();
-        ToolStripButton studioLinkButton = toolButtonsRender.getStudioLinkButton();
-        ToolStripButton schedulerLinkButton = toolButtonsRender.getSchedulerHighlightedLinkButton();
-        ToolStripButton automationDashboardLinkButton = toolButtonsRender.getAutomationDashboardLinkButton();
-        ToolStripButton logoutButton = toolButtonsRender.getLogoutButton(login, SchedulerPage.this.controller);
+        ToolStrip additionalLogoCenter = new ToolStrip();
+        additionalLogoCenter.setHeight(logoStripHeight);
+        additionalLogoCenter.setWidth("10%");
+        additionalLogoCenter.setBackgroundImage("");
+        additionalLogoCenter.setBackgroundColor(logoStripBackgroundColor);
+        additionalLogoCenter.setMargin(0);
+        additionalLogoCenter.setBorder(logoStripBorder);
+        additionalLogoCenter.setAlign(Alignment.RIGHT);
+        Img logoAzureImg = new Img(SchedulerImagesUnbundled.EXTRA_LOGO_CENTER, 135, logoStripHeight);
+        additionalLogoCenter.addMember(logoAzureImg);
 
         tools.addMenuButton(portalMenuButton);
         tools.addMenuButton(adminMenuButton);
@@ -533,18 +559,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         tools.addFill();
         tools.addMember(schedulerStatusLabelLayout);
         tools.addFill();
-        tools.addButton(automationDashboardLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(studioLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(schedulerLinkButton);
-        tools.addSpacer(12);
-        tools.addButton(resourceManagerLinkButton);
-        tools.addSpacer(2);
-        tools.addSeparator();
-        tools.addSpacer(2);
-        tools.addButton(logoutButton);
-        tools.addSpacer(10);
+        tools.addMember(additionalLogoCenter);
 
         // disable all controls at first, next event will sort it out
         this.statusChanged(SchedulerStatus.KILLED);
@@ -572,6 +587,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
                 schedKillButton.setEnabled(false);
                 schedShutdownButton.setEnabled(false);
                 schedulerStatusLabel.setIcon(SchedulerImages.instance.scheduler_shutdown_16().getSafeUri().asString());
+                break;
             case KILLED:
                 schedStartButton.setEnabled(false);
                 schedStopButton.setEnabled(false);
@@ -799,10 +815,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
 
     @Override
     public void logImportantMessage(String message) {
-        long dt = System.currentTimeMillis() - this.lastCriticalMessage;
-        if (dt > SchedulerConfig.get().getClientRefreshTime() * 4) {
-            this.errorButton.hide();
-        }
+        logMessage(message);
     }
 
     @Override

--- a/scheduler-portal/src/main/webapp/portal.css
+++ b/scheduler-portal/src/main/webapp/portal.css
@@ -24,9 +24,50 @@
 .paddingLeftAndRight {
 	padding-left: 10px;
 	padding-right: 10px;
-	
 }
 
+.brand-logo{
+	padding-left: 6px;
+	padding-right: 6px;
+    top: 0px!important;
+}
+
+.pa-shortcuts > div {
+	position:static!important;
+    display: -webkit-inline-flex!important;;
+    display: -ms-inline-flexbox!important;;
+    display: -moz-flex!important;;
+    display: inline-flex!important;
+}
+
+.pa-shortcuts > div > div {
+	overflow-x: hidden;
+	transition: width 300ms;
+	transition-timing-function: ease;
+	-webkit-transition: width 300ms;
+	-webkit-transition-timing-function: ease;
+	margin-left: 4px!important;
+	position: static!important;
+}
+
+.pa-shortcuts > .active {
+	background-color: #f76800;
+	color: white;
+}
+
+.pa-shortcuts {
+    padding-left: 0px!important;
+    padding-right: 0px!important;
+	transition: width 500ms;
+	transition-timing-function: ease;
+	-webkit-transition: width 500ms;
+	-webkit-transition-timing-function: ease;
+	display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    float: right;
+    width: auto!important;
+}
 
 .toolStripButton, .toolStripButtonOver, .toolStripButtonFocused, .toolStripButtonFocusedOver, .toolStripButtonDown, .toolStripButtonFocusedDown, .toolStripButtonSelected, .toolStripButtonSelectedFocused, .toolStripButtonSelectedDown, .toolStripButtonSelectedFocusedDown, .toolStripButtonSelectedOver, .toolStripButtonSelectedFocusedOver, .toolStripButtonDisabled, .toolStripButtonSelectedDisabled {
     color: #777 !important;


### PR DESCRIPTION
In this PR, we update the portals navbars to sync with the new studio navbar:
- Portals shortcuts in first row
- powered-by logo in second row
- Remove Proactive logo and replace it with Activeeon logo
- Apply a few lambdas and apply sonarLint receommendations