### PR TITLE
fix: show advance configurations by default when edit node source

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -211,7 +211,7 @@ public abstract class NodeSourceWindow {
      */
     protected abstract void beforeSubmit();
 
-    protected void buildForm() {
+    protected void buildForm(boolean showAdvanced) {
         VLayout nodeSourceWindowLayout = new VLayout();
         nodeSourceWindowLayout.setMargin(5);
         nodeSourceWindowLayout.setMembersMargin(0);
@@ -263,7 +263,7 @@ public abstract class NodeSourceWindow {
 
         isAdvanced = new CheckboxItem();
         isAdvanced.setTitle("Advanced configuration");
-        isAdvanced.setDefaultValue(false);
+        isAdvanced.setDefaultValue(showAdvanced);
         isAdvanced.addChangedHandler(e -> {
             isAdvanceChangedHandler();
         });

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/creation/CreateNodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/creation/CreateNodeSourceWindow.java
@@ -47,7 +47,7 @@ public class CreateNodeSourceWindow extends NodeSourceWindow {
 
     public CreateNodeSourceWindow(RMController controller) {
         super(controller, "Add Node Source", "Updating Available Infrastructures and Policies");
-        buildForm();
+        buildForm(false);
     }
 
     @Override

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditDynamicParametersWindow.java
@@ -49,7 +49,7 @@ public class EditDynamicParametersWindow extends EditNodeSourceWindow {
     public static final String WINDOW_TITLE = "Update Dynamic Parameters";
 
     public EditDynamicParametersWindow(RMController controller, String nodeSourceName) {
-        super(controller, nodeSourceName, WINDOW_TITLE);
+        super(controller, nodeSourceName, WINDOW_TITLE, false);
     }
 
     @Override

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/edition/EditNodeSourceWindow.java
@@ -52,15 +52,19 @@ public class EditNodeSourceWindow extends NodeSourceWindow {
 
     public EditNodeSourceWindow(RMController controller, String nodeSourceName) {
         super(controller, WINDOW_TITLE, WAITING_MESSAGE);
-        setAttributesAndBuildForm(nodeSourceName);
+        // Hiding advanced configuration causes the problem of losing advanced configuration value
+        // when editing a node source. So before fixing the problem of losing form value, we show advanced configuration
+        // by default when editing a node source.
+        setAttributesAndBuildForm(nodeSourceName, true);
     }
 
-    protected EditNodeSourceWindow(RMController controller, String nodeSourceName, String windowTitle) {
+    protected EditNodeSourceWindow(RMController controller, String nodeSourceName, String windowTitle,
+            boolean showAdvanced) {
         super(controller, windowTitle, WAITING_MESSAGE);
-        setAttributesAndBuildForm(nodeSourceName);
+        setAttributesAndBuildForm(nodeSourceName, showAdvanced);
     }
 
-    private void setAttributesAndBuildForm(String nodeSourceName) {
+    private void setAttributesAndBuildForm(String nodeSourceName, boolean showAdvanced) {
         this.nodeSourceName = nodeSourceName;
         // Before for editing dynamic parameters,
         // we were calling it twice (once in EditDynamicParametersWindow constructor,
@@ -69,8 +73,8 @@ public class EditNodeSourceWindow extends NodeSourceWindow {
         // which calls buildForm only once. It does not work when called once.
         // So now, for both editing dynamic parameters and editing undeployed NS
         // we will call it twice.
-        buildForm();
-        buildForm();
+        buildForm(showAdvanced);
+        buildForm(showAdvanced);
     }
 
     @Override


### PR DESCRIPTION
Currently we have the problem of losing form value when editing a node source without showing advanced configuration. The proper fix is quite complex, we use a temporary workaround of showing advanced configuration to avoid this problem.