### PR TITLE
Fix discrepancy between output mode stored in the model and the view.

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/OutputController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/OutputController.java
@@ -316,6 +316,7 @@ public class OutputController extends AbstractSelectedTargetController<OutputMod
             this.changeCurrentOutput(null, false);
         } else {
             this.changeCurrentOutput(job.getId().toString(), true);
+            this.view.refreshOutputModeSelect(model.getOutputMode());
             this.checkLiveEnabled(job);
             if (this.model.isLive()) {
                 this.startLiveOutput();
@@ -341,6 +342,7 @@ public class OutputController extends AbstractSelectedTargetController<OutputMod
         boolean changed = this.model.setOutputMode(outputMode);
         if (changed) {
             this.refreshOutput();
+            this.view.refreshOutputModeSelect(outputMode);
         }
     }
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/OutputView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/OutputView.java
@@ -149,6 +149,11 @@ public class OutputView extends AbstractOutputDisplayView<OutputModel, OutputCon
         this.label.show();
     }
 
+    public void refreshOutputModeSelect(OutputMode mode) {
+        this.outSelect.setValue(mode.label);
+        this.outSelect.redraw();
+    }
+
     /**
      * Updates the output view to display the given output after update.
      */


### PR DESCRIPTION
- when choosing Full logs, the view (select list) was not updated correctly, creating a difference between the value stored in the model and in the view.
- when switching between jobs, each select widget kept its own local value, creating even more differences with the model (which stores a unique value for all jobs).

This fix makes sure, that after changing the value from the drop/down list, the widget is updated successfully, and after selecting a different job, we use the unique value stored in the model.