### PR TITLE
fix the node source import bugs of losing file/boolean fields value and escaped special characters

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/PluginDescriptor.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/PluginDescriptor.java
@@ -141,6 +141,14 @@ public class PluginDescriptor {
         public boolean isImportant() {
             return important;
         }
+
+        @Override
+        public String toString() {
+            return "Field{" + "name='" + name + '\'' + ", value='" + value + '\'' + ", description='" + description +
+                   '\'' + ", password=" + password + ", credential=" + credential + ", file=" + file + ", textarea=" +
+                   textarea + ", checkbox=" + checkbox + ", dynamic=" + dynamic + ", sectionSelector=" +
+                   sectionSelector + ", important=" + important + '}';
+        }
     }
 
     public PluginDescriptor(String pluginName, String pluginDescription, Map<Integer, String> sectionDescriptions,

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/PluginDescriptor.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/PluginDescriptor.java
@@ -141,14 +141,6 @@ public class PluginDescriptor {
         public boolean isImportant() {
             return important;
         }
-
-        @Override
-        public String toString() {
-            return "Field{" + "name='" + name + '\'' + ", value='" + value + '\'' + ", description='" + description +
-                   '\'' + ", password=" + password + ", credential=" + credential + ", file=" + file + ", textarea=" +
-                   textarea + ", checkbox=" + checkbox + ", dynamic=" + dynamic + ", sectionSelector=" +
-                   sectionSelector + ", important=" + important + '}';
-        }
     }
 
     public PluginDescriptor(String pluginName, String pluginDescription, Map<Integer, String> sectionDescriptions,

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -151,6 +151,8 @@ public abstract class NodeSourceWindow {
      */
     private Map<String, List<FormItem>> formItemsByName;
 
+    private Map<String, List<FormItem>> advancedFormItems = new HashMap<>();
+
     private Map<String, String> hiddenItems = new HashMap<>();
 
     /**
@@ -335,12 +337,33 @@ public abstract class NodeSourceWindow {
         this.window.centerInPage();
     }
 
+    public static native void nativeConsoleLog(String s)
+    /*-{ console.log( s ); }-*/;
+
+    private void addAdvancedFormItems(String pluginName, FormItem formItem) {
+        List<FormItem> items = advancedFormItems.getOrDefault(pluginName, new ArrayList<>());
+        items.add(formItem);
+        advancedFormItems.put(pluginName, items);
+    }
+
     private void isAdvanceChangedHandler() {
-        hideAllPluginFormItems();
-        populateFormValues(() -> {
-            resetFormForInfrastructureSelectChange();
-            resetFormForPolicySelectChange();
-        });
+        //TODO
+        nativeConsoleLog("advancedFormItems " + advancedFormItems);
+        if (isAdvanced.getValueAsBoolean()) {
+            this.advancedFormItems.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
+                                  .stream()
+                                  .forEach(FormItem::show);
+            this.advancedFormItems.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
+                                  .stream()
+                                  .forEach(FormItem::show);
+        } else {
+            this.advancedFormItems.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
+                                  .stream()
+                                  .forEach(FormItem::hide);
+            this.advancedFormItems.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
+                                  .stream()
+                                  .forEach(FormItem::hide);
+        }
     }
 
     private void createButtons(VLayout nodeSourceWindowLayout) {
@@ -676,6 +699,8 @@ public abstract class NodeSourceWindow {
             formItemsForField.forEach(formItem -> {
                 if (pluginField.isImportant()) {
                     formItem.setTitleStyle("important-message");
+                } else {
+                    addAdvancedFormItems(plugin.getPluginName(), formItem);
                 }
                 if (pluginField.isCheckbox()) {
                     formItem.setDefaultValue(pluginField.getValue());

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -106,6 +106,8 @@ public abstract class NodeSourceWindow {
 
     private static final String HIDDEN_INFRA = "hidden-infra";
 
+    private static final String FORM_ITEM_ATTR_ADVANCED = "advanced";
+
     public static final String FIELD_SEPARATOR = "\u0003";
 
     public static final String ROW_SEPARATOR = "\u0006";
@@ -340,20 +342,20 @@ public abstract class NodeSourceWindow {
         if (isAdvanced.getValueAsBoolean()) {
             this.formItemsByName.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean("advanced"))
+                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
                                 .forEach(FormItem::show);
             this.formItemsByName.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean("advanced"))
+                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
                                 .forEach(FormItem::show);
         } else {
             this.formItemsByName.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean("advanced"))
+                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
                                 .forEach(FormItem::hide);
             this.formItemsByName.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean("advanced"))
+                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
                                 .forEach(FormItem::hide);
         }
     }
@@ -438,7 +440,7 @@ public abstract class NodeSourceWindow {
                                                                    (List<FormItem>) Collections.EMPTY_LIST)) {
             formItem.show();
             // when isAdvanced is unchecked, the advanced form items should be hidden.
-            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean("advanced")) {
+            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED)) {
                 formItem.hide();
             }
         }
@@ -501,7 +503,7 @@ public abstract class NodeSourceWindow {
                                                                    (List<FormItem>) Collections.EMPTY_LIST)) {
             formItem.show();
             // when isAdvanced is unchecked, the advanced form items should be hidden.
-            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean("advanced")) {
+            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED)) {
                 formItem.hide();
             }
         }
@@ -699,7 +701,7 @@ public abstract class NodeSourceWindow {
                 if (pluginField.isImportant()) {
                     formItem.setTitleStyle("important-message");
                 }
-                formItem.setAttribute("advanced", !pluginField.isImportant());
+                formItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, !pluginField.isImportant());
                 if (pluginField.isCheckbox()) {
                     formItem.setDefaultValue(pluginField.getValue());
                 } else {
@@ -772,13 +774,21 @@ public abstract class NodeSourceWindow {
                 if (plugin.getSectionDescriptions().containsKey(pluginField.getSectionSelector())) {
                     RowSpacerItem rowSpacerItem = new RowSpacerItem(plugin.getPluginName() + "separator" +
                                                                     currentSectionSelector);
-                    allFormItems.add(rowSpacerItem);
                     StaticTextItem staticTextItem = new StaticTextItem(plugin.getPluginName() + "staticTextItem" +
                                                                        currentSectionSelector,
                                                                        plugin.getSectionDescriptions()
                                                                              .get(pluginField.getSectionSelector()) +
                                                                                                ":");
                     staticTextItem.setTitleStyle("sectionParametersStyle");
+                    // check whether the section is visible when "isAdvanced" is not checked (i.e., not showing not-important fields).
+                    final int finalCurrentSectionSelector = currentSectionSelector;
+                    // if this section contains none of important fields, the section title related form items should be hidden when "isAdvanced" is not checked.
+                    boolean advancedSection = pluginFields.stream()
+                                                          .filter(p -> p.getSectionSelector() == finalCurrentSectionSelector)
+                                                          .noneMatch(p -> p.isImportant());
+                    rowSpacerItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, advancedSection);
+                    staticTextItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, advancedSection);
+                    allFormItems.add(rowSpacerItem);
                     allFormItems.add(staticTextItem);
                 }
             }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -59,6 +59,7 @@ import org.ow2.proactive_grid_cloud_portal.rm.shared.RMConfig;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.user.client.ui.HTML;
 import com.smartgwt.client.types.*;
 import com.smartgwt.client.widgets.IButton;
 import com.smartgwt.client.widgets.Label;
@@ -864,9 +865,10 @@ public abstract class NodeSourceWindow {
     }
 
     public void importNodeSourceFromJson(String importedNodeSourceJsonString) {
+        String unescapedNodeSourceJsonString = new HTML(importedNodeSourceJsonString).getText();
         NodeSourceConfiguration nodeSourceConfiguration;
         try {
-            nodeSourceConfiguration = new NodeSourceConfigurationParser().parseNodeSourceConfiguration(importedNodeSourceJsonString);
+            nodeSourceConfiguration = new NodeSourceConfigurationParser().parseNodeSourceConfiguration(unescapedNodeSourceJsonString);
             this.nodeSourceNameText.setValue(nodeSourceConfiguration.getNodeSourceName());
             this.nodesRecoverableCheckbox.setValue(nodeSourceConfiguration.getNodesRecoverable());
             fillPluginFormItems(nodeSourceConfiguration);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -106,7 +106,7 @@ public abstract class NodeSourceWindow {
 
     private static final String HIDDEN_INFRA = "hidden-infra";
 
-    private static final String FORM_ITEM_ATTR_ADVANCED = "advanced";
+    private static final String IMPORTANT_ITEM_ATTR = "importantField";
 
     public static final String FIELD_SEPARATOR = "\u0003";
 
@@ -335,27 +335,26 @@ public abstract class NodeSourceWindow {
         this.window.centerInPage();
     }
 
-    public static native void nativeConsoleLog(String s)
-    /*-{ console.log( s ); }-*/;
-
     private void isAdvanceChangedHandler() {
         if (isAdvanced.getValueAsBoolean()) {
+            // when checked isAdvanced, all the not-important fields should be shown.
             this.formItemsByName.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
+                                .filter(i -> !i.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR))
                                 .forEach(FormItem::show);
             this.formItemsByName.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
+                                .filter(i -> !i.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR))
                                 .forEach(FormItem::show);
         } else {
+            // when unchecked isAdvanced, all the not-important fields should be hidden.
             this.formItemsByName.getOrDefault(infrastructureSelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
+                                .filter(i -> !i.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR))
                                 .forEach(FormItem::hide);
             this.formItemsByName.getOrDefault(policySelectItem.getValueAsString(), new ArrayList<>())
                                 .stream()
-                                .filter(i -> i.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED))
+                                .filter(i -> !i.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR))
                                 .forEach(FormItem::hide);
         }
     }
@@ -438,10 +437,9 @@ public abstract class NodeSourceWindow {
         String policyPluginName = this.policySelectItem.getValueAsString();
         for (FormItem formItem : this.formItemsByName.getOrDefault(policyPluginName,
                                                                    (List<FormItem>) Collections.EMPTY_LIST)) {
-            formItem.show();
-            // when isAdvanced is unchecked, the advanced form items should be hidden.
-            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED)) {
-                formItem.hide();
+            // when unchecked "isAdvanced", only the important fields should be shown, otherwise, all the fields should be shown.
+            if (isAdvanced.getValueAsBoolean() || formItem.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR)) {
+                formItem.show();
             }
         }
         this.previousSelectedPolicy = policyPluginName;
@@ -501,10 +499,9 @@ public abstract class NodeSourceWindow {
         String infrastructurePluginName = this.infrastructureSelectItem.getValueAsString();
         for (FormItem formItem : this.formItemsByName.getOrDefault(infrastructurePluginName,
                                                                    (List<FormItem>) Collections.EMPTY_LIST)) {
-            formItem.show();
-            // when isAdvanced is unchecked, the advanced form items should be hidden.
-            if ((!isAdvanced.getValueAsBoolean()) && formItem.getAttributeAsBoolean(FORM_ITEM_ATTR_ADVANCED)) {
-                formItem.hide();
+            // when unchecked "isAdvanced", only the important fields should be shown, otherwise, all the fields should be shown.
+            if (isAdvanced.getValueAsBoolean() || formItem.getAttributeAsBoolean(IMPORTANT_ITEM_ATTR)) {
+                formItem.show();
             }
         }
         this.previousSelectedInfrastructure = infrastructurePluginName;
@@ -701,7 +698,7 @@ public abstract class NodeSourceWindow {
                 if (pluginField.isImportant()) {
                     formItem.setTitleStyle("important-message");
                 }
-                formItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, !pluginField.isImportant());
+                formItem.setAttribute(IMPORTANT_ITEM_ATTR, pluginField.isImportant());
                 if (pluginField.isCheckbox()) {
                     formItem.setDefaultValue(pluginField.getValue());
                 } else {
@@ -782,12 +779,13 @@ public abstract class NodeSourceWindow {
                     staticTextItem.setTitleStyle("sectionParametersStyle");
                     // check whether the section is visible when "isAdvanced" is not checked (i.e., not showing not-important fields).
                     final int finalCurrentSectionSelector = currentSectionSelector;
-                    // if this section contains none of important fields, the section title related form items should be hidden when "isAdvanced" is not checked.
-                    boolean advancedSection = pluginFields.stream()
-                                                          .filter(p -> p.getSectionSelector() == finalCurrentSectionSelector)
-                                                          .noneMatch(p -> p.isImportant());
-                    rowSpacerItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, advancedSection);
-                    staticTextItem.setAttribute(FORM_ITEM_ATTR_ADVANCED, advancedSection);
+                    // if this section contains any of important fields, the section title related form items should always be shown.
+                    // Otherwise, it should be hidden when "isAdvanced" is not checked.
+                    boolean importantSection = pluginFields.stream()
+                                                           .filter(p -> p.getSectionSelector() == finalCurrentSectionSelector)
+                                                           .anyMatch(PluginDescriptor.Field::isImportant);
+                    rowSpacerItem.setAttribute(IMPORTANT_ITEM_ATTR, importantSection);
+                    staticTextItem.setAttribute(IMPORTANT_ITEM_ATTR, importantSection);
                     allFormItems.add(rowSpacerItem);
                     allFormItems.add(staticTextItem);
                 }
@@ -977,11 +975,9 @@ public abstract class NodeSourceWindow {
     }
 
     public void replaceInfrastructureItems(PluginDescriptor infrastructurePluginDescriptor) {
-        nativeConsoleLog("replaceInfrastructureItems");
         List<FormItem> allNodeSourcePluginsFormItems = Arrays.stream(this.nodeSourcePluginsForm.getFields())
                                                              .collect(Collectors.toList());
         replaceInfrastructureItemsInItemList(infrastructurePluginDescriptor, allNodeSourcePluginsFormItems);
-        nativeConsoleLog("replaceInfrastructureItemsInItemList");
         this.nodeSourcePluginsForm.setFields(allNodeSourcePluginsFormItems.toArray(new FormItem[0]));
     }
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/NodeSourceWindow.java
@@ -896,10 +896,9 @@ public abstract class NodeSourceWindow {
     }
 
     public void importNodeSourceFromJson(String importedNodeSourceJsonString) {
-        String unescapedNodeSourceJsonString = new HTML(importedNodeSourceJsonString).getText();
         NodeSourceConfiguration nodeSourceConfiguration;
         try {
-            nodeSourceConfiguration = new NodeSourceConfigurationParser().parseNodeSourceConfiguration(unescapedNodeSourceJsonString);
+            nodeSourceConfiguration = new NodeSourceConfigurationParser().parseNodeSourceConfiguration(importedNodeSourceJsonString);
             this.nodeSourceNameText.setValue(nodeSourceConfiguration.getNodeSourceName());
             this.nodesRecoverableCheckbox.setValue(nodeSourceConfiguration.getNodesRecoverable());
             fillPluginFormItems(nodeSourceConfiguration);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportLayout.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/load/ImportLayout.java
@@ -35,6 +35,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -66,7 +67,12 @@ public abstract class ImportLayout extends VLayout {
 
     public abstract CatalogKind getKind();
 
-    public abstract void handleImport(String submitResult);
+    public void unescapeAndImport(String submitResult) {
+        String unescapedNodeSourceJsonString = new HTML(submitResult).getText();
+        handleImport(unescapedNodeSourceJsonString);
+    }
+
+    protected abstract void handleImport(String submitResult);
 
     private void createImportPanel(String layoutTitle) {
         this.importPanel = new VerticalPanel();
@@ -102,7 +108,7 @@ public abstract class ImportLayout extends VLayout {
         this.selectedImportMethodPanel.clear();
         String selectedOption = this.importMethodList.getSelectedValue();
         if (selectedOption.equals(ImportFromFilePanel.FILE_OPTION_NAME)) {
-            this.selectedImportMethodPanel.add(new ImportFromFilePanel(importCompleteEvent -> handleImport(importCompleteEvent.getResults())));
+            this.selectedImportMethodPanel.add(new ImportFromFilePanel(importCompleteEvent -> unescapeAndImport(importCompleteEvent.getResults())));
         } else if (selectedOption.equals(ImportFromCatalogPanel.CATALOG_OPTION_NAME)) {
             addImportFromCatalogPanelOrFail();
         }
@@ -113,7 +119,7 @@ public abstract class ImportLayout extends VLayout {
             this.selectedImportMethodPanel.add(new ImportFromCatalogPanel(getKind(), new RequestCallback() {
                 @Override
                 public void onResponseReceived(Request request, Response response) {
-                    handleImport(response.getText());
+                    unescapeAndImport(response.getText());
                 }
 
                 @Override


### PR DESCRIPTION
- in node source windows, change isAdvanceChangedHandler to hide/show not-important fields instead of clear then re-create formItems to fix the bug of losing file/boolean fields values when importing a node source, or changing the selected infrastructure/policy.
- un-escape the imported node source / infrastructure / policy to avoid special characters such as `&` is changed to `&amp;` during import.