### PR TITLE
fix: remote visu and task-centric view scrolling

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -115,9 +115,11 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
         this.setSelectionType(SelectionStyle.SINGLE);
         this.setSelectionProperty("isSelected");
         this.sort(TasksCentricColumnsFactory.JOB_ID_ATTR.getName(), SortDirection.DESCENDING);
-        //        These lines break task centric scrolling
-        //        this.setShowRecordComponents(true);
-        //        this.setShowRecordComponentsByCell(true);
+        //These settings are needed to show the remote visu, but in the task-centric view, they break task centric scrolling
+        if (!usedWithTaskCentricView) {
+            this.setShowRecordComponents(true);
+            this.setShowRecordComponentsByCell(true);
+        }
     }
 
     protected Map<GridColumns, ListGridField> buildListGridField() {


### PR DESCRIPTION
This PR https://github.com/ow2-proactive/scheduling-portal/pull/643 introduces a bug: the remote visualization icon can't be correctly shown.
To fix the bug, showRecordComponents and showRecordComponentsByCell are set to true when it is not the task-centric view. (These settings break scrolling in task-centric view.)