### PR TITLE
Make jobs/tasks grid view state persistent

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/ItemsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/ItemsListGrid.java
@@ -32,14 +32,14 @@ import java.util.Map;
 import org.ow2.proactive_grid_cloud_portal.common.client.model.LoginModel;
 
 import com.smartgwt.client.data.AdvancedCriteria;
-import com.smartgwt.client.data.DSCallback;
 import com.smartgwt.client.data.DSRequest;
-import com.smartgwt.client.data.DSResponse;
 import com.smartgwt.client.data.DataSource;
 import com.smartgwt.client.data.DataSourceField;
 import com.smartgwt.client.data.RecordList;
 import com.smartgwt.client.data.fields.DataSourceIntegerField;
 import com.smartgwt.client.data.fields.DataSourceTextField;
+import com.smartgwt.client.widgets.events.DrawEvent;
+import com.smartgwt.client.widgets.events.DrawHandler;
 import com.smartgwt.client.widgets.grid.ListGrid;
 import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.events.*;
@@ -159,6 +159,19 @@ public abstract class ItemsListGrid<I> extends ListGrid {
                 selectionUpdatedHandler(event);
             }
         });
+
+        this.addFieldStateChangedHandler(new FieldStateChangedHandler() {
+            public void onFieldStateChanged(FieldStateChangedEvent event) {
+                fieldStateChangedHandler(event);
+            }
+        });
+
+        this.addDrawHandler(new DrawHandler() {
+            public void onDraw(DrawEvent event) {
+                drawHandler(event);
+            }
+        });
+
     }
 
     /**
@@ -210,6 +223,19 @@ public abstract class ItemsListGrid<I> extends ListGrid {
     protected abstract void selectionChangedHandler(SelectionEvent event);
 
     protected abstract void selectionUpdatedHandler(SelectionUpdatedEvent event);
+
+    /**
+     * Called when the grid state is changed to save the grid view state in the local storage
+     * The possible actions that might trigger this function are: resize of a column, change sorting, hide/show columns
+     * @param event
+     */
+    protected abstract void fieldStateChangedHandler(FieldStateChangedEvent event);
+
+    /**
+     * Called when the grid is loaded (page refresh, or login in) to restore the previous grid view state from the local storage
+     * @param event
+     */
+    protected abstract void drawHandler(DrawEvent event);
 
     /**
      * Apply the local filter to the grid.

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.ow2.proactive_grid_cloud_portal.common.client.Settings;
+import org.ow2.proactive_grid_cloud_portal.common.client.model.LogModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.Job;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.JobPriority;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.JobStatus;
@@ -52,9 +54,11 @@ import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.ListGridFieldType;
 import com.smartgwt.client.types.SortDirection;
 import com.smartgwt.client.util.SC;
+import com.smartgwt.client.widgets.events.DrawEvent;
 import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
 import com.smartgwt.client.widgets.grid.SortNormalizer;
+import com.smartgwt.client.widgets.grid.events.FieldStateChangedEvent;
 import com.smartgwt.client.widgets.grid.events.SelectionEvent;
 import com.smartgwt.client.widgets.grid.events.SelectionUpdatedEvent;
 import com.smartgwt.client.widgets.menu.Menu;
@@ -67,6 +71,9 @@ import com.smartgwt.client.widgets.menu.MenuItem;
  * @author The activeeon team.
  */
 public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListener {
+
+    //specifies the variable name of the job grid view state in the local storage
+    private static final String JOBS_GRID_VIEW_STATE = "jobsGridViewState";
 
     private static final SortSpecifier[] DEFAULT_SORT = new SortSpecifier[] { new SortSpecifier(STATE_ATTR.getName(),
                                                                                                 SortDirection.ASCENDING),
@@ -93,6 +100,25 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
         super.build();
         this.setSelectionProperty("isSelected");
         this.setSort(DEFAULT_SORT);
+    }
+
+    @Override
+    protected void fieldStateChangedHandler(FieldStateChangedEvent event) {
+        //save the view state in the local storage
+        Settings.get().setSetting(JOBS_GRID_VIEW_STATE, this.getViewState());
+    }
+
+    @Override
+    protected void drawHandler(DrawEvent event) {
+        try {
+            final String viewState = Settings.get().getSetting(JOBS_GRID_VIEW_STATE);
+            if (viewState != null) {
+                // restore any previously saved view state for this grid
+                this.setViewState(viewState);
+            }
+        } catch (Exception e) {
+            LogModel.getInstance().logImportantMessage("Failed to restore jobs grid view state " + e);
+        }
     }
 
     @Override

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/ExpandableTasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/ExpandableTasksListGrid.java
@@ -25,12 +25,16 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks;
 
+import org.ow2.proactive_grid_cloud_portal.common.client.Settings;
+import org.ow2.proactive_grid_cloud_portal.common.client.model.LogModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.Task;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.TasksController;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.GridColumns;
 
 import com.smartgwt.client.widgets.Canvas;
+import com.smartgwt.client.widgets.events.DrawEvent;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
+import com.smartgwt.client.widgets.grid.events.FieldStateChangedEvent;
 import com.smartgwt.client.widgets.layout.VLayout;
 import com.smartgwt.client.widgets.viewer.DetailViewer;
 import com.smartgwt.client.widgets.viewer.DetailViewerField;
@@ -43,6 +47,9 @@ import com.smartgwt.client.widgets.viewer.DetailViewerRecord;
  *
  */
 public class ExpandableTasksListGrid extends TasksListGrid {
+
+    //specifies the variable name of the task grid view state in the local storage
+    private static final String TASKS_GRID_VIEW_STATE = "tasksGridViewState";
 
     /**
      * The record for the expand component to be shown.
@@ -110,5 +117,25 @@ public class ExpandableTasksListGrid extends TasksListGrid {
             this.expandRecord = record;
         }
         return record;
+    }
+
+    @Override
+    protected void fieldStateChangedHandler(FieldStateChangedEvent event) {
+        //save the view state in the local storage
+        Settings.get().setSetting(TASKS_GRID_VIEW_STATE, this.getViewState());
+    }
+
+    @Override
+    protected void drawHandler(DrawEvent event) {
+        try {
+            String viewTaskState = Settings.get().getSetting(TASKS_GRID_VIEW_STATE);
+            if (viewTaskState != null) {
+                // restore any previously saved view state for this grid
+                this.setViewState(viewTaskState);
+            }
+        } catch (Exception e) {
+            LogModel.getInstance().logImportantMessage("Failed to restore tasks grid view state " + e);
+        }
+
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/tasks/TasksListGrid.java
@@ -30,7 +30,6 @@ import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tas
 import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.TasksColumnsFactory.NAME_ATTR;
 import static org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.tasks.TasksColumnsFactory.STATUS_ATTR;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,9 +60,11 @@ import com.smartgwt.client.widgets.Label;
 import com.smartgwt.client.widgets.Window;
 import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
+import com.smartgwt.client.widgets.events.DrawEvent;
 import com.smartgwt.client.widgets.grid.CellFormatter;
 import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
+import com.smartgwt.client.widgets.grid.events.FieldStateChangedEvent;
 import com.smartgwt.client.widgets.grid.events.SelectionEvent;
 import com.smartgwt.client.widgets.grid.events.SelectionUpdatedEvent;
 import com.smartgwt.client.widgets.layout.HLayout;
@@ -475,6 +476,16 @@ public class TasksListGrid extends ItemsListGrid<Task> implements TasksUpdatedLi
 
     @Override
     protected void selectionUpdatedHandler(SelectionUpdatedEvent event) {
+        // Nothing to do
+    }
+
+    @Override
+    protected void fieldStateChangedHandler(FieldStateChangedEvent event) {
+        // Nothing to do
+    }
+
+    @Override
+    protected void drawHandler(DrawEvent event) {
         // Nothing to do
     }
 


### PR DESCRIPTION
-Add jobs/tasks grid view state to the local storage as a JSON configuration.
-Add 2 listeners: one on jobs/tasks grid state change and one on the page (grid) loading.
-Save the grid view state on every state change. Changes include: resize of columns, hide/show columns, columns order, change the sorting columns, etc.
-Load the stored grid view state on every page loading (e.g., refresh, login, etc) for both jobs and tasks.