### PR TITLE
Add log4j2 configuration to scheduler and rm portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,9 @@ subprojects {
         compile 'commons-fileupload:commons-fileupload:1.2'
         compile 'org.apache.httpcomponents:httpclient:4.3.6'
         compile 'org.apache.commons:gwt-commons-patricia-trie:4.0'
-        compile("org.ow2.proactive:common-http:${schedulingPortalVersion}")
+        compile("org.ow2.proactive:common-http:${schedulingPortalVersion}") {
+            exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+        }
         compile("org.ow2.proactive:scheduling-api-graphql-beans-input-gwt:${schedulingPortalVersion}")
         compile("org.ow2.proactive:scheduling-api-graphql-common-gwt:${schedulingPortalVersion}")
         compile("org.ow2.proactive:scheduling-api-graphql-client-gwt:${schedulingPortalVersion}")
@@ -139,7 +141,8 @@ project(':rm-portal') {
         compile 'codemirror:codemirror2-gwt:1.2.0'
         compile 'org.jboss.resteasy:resteasy-client:3.0.26.Final'
 
-        runtime 'org.slf4j:slf4j-log4j12:1.7.16'
+        runtime 'org.apache.logging.log4j:log4j-web:2.4.1'
+        runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.4.1'
         testRuntime 'org.slf4j:slf4j-simple:1.7.16'
         compile 'org.codehaus.jettison:jettison:1.2'
         compile project(':common-portal')
@@ -163,8 +166,8 @@ project(':scheduler-portal') {
         compile 'org.apache.commons:commons-csv:1.1'
 
         compile project(':common-portal')
-
-        runtime 'org.slf4j:slf4j-log4j12:1.7.16'
+        runtime 'org.apache.logging.log4j:log4j-web:2.4.1'
+        runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.4.1'
         testRuntime 'org.slf4j:slf4j-simple:1.7.16'
     }
 

--- a/rm-portal/src/main/resources/log4j2.xml
+++ b/rm-portal/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="INFO">
+    <Properties>
+        <Property name="pa.scheduler.home">.</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="RollingFile" fileName="${sys:pa.scheduler.home}/logs/rm-portal.log"
+                     filePattern="${sys:pa.scheduler.home}/logs/rm-portal-%d{yyyy-MM-dd}-%i.log.zip">
+            <PatternLayout>
+                <pattern>%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="20" compressionLevel="9"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.ow2.proactive_grid_cloud_portal.rm.server" level="info" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/rm-portal/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/rm-portal/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="maxFormContentSize">2000000</Set>
+    <Set name="maxFormKeys">2000</Set>
+</Configure>

--- a/scheduler-portal/src/main/resources/log4j2.xml
+++ b/scheduler-portal/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="INFO">
+    <Properties>
+        <Property name="pa.scheduler.home">.</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="RollingFile" fileName="${sys:pa.scheduler.home}/logs/scheduler-portal.log"
+                     filePattern="${sys:pa.scheduler.home}/logs/scheduler-portal-%d{yyyy-MM-dd}-%i.log.zip">
+            <PatternLayout>
+                <pattern>%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="20" compressionLevel="9"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.ow2.proactive_grid_cloud_portal.scheduler.server" level="info" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/scheduler-portal/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/scheduler-portal/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="maxFormContentSize">2000000</Set>
+    <Set name="maxFormKeys">2000</Set>
+</Configure>


### PR DESCRIPTION
This outputs logs in a dedicated log file

Additionally, add jetty-web configuration to override default jetty parameters and handle large forms submission (for example, when resubmitting jobs)