### PR TITLE
fix-pagination-bug

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsPaginationController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsPaginationController.java
@@ -96,7 +96,7 @@ public class JobsPaginationController extends PaginationController<JobsPaginatio
     @Override
     public boolean hasPrevious() {
         //GraphQL fetches the jobs starting from the oldest
-        return model.hasNextPage();
+        return model.hasNextPage() && model.getPage() > 0;
     }
 
     @Override


### PR DESCRIPTION
When submitting more than 100 jobs, the pagination does not work properly. 
After clicking on the "Newest" button, "Newer" button remains enabled. 