### PR TITLE
click-on-submit-then-check-closes-the-modal

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -284,6 +284,8 @@ public class SubmitWindow {
 
     private int noOfFields;
 
+    private boolean checkVariables = false;
+
     /**
      * Default constructor
      *
@@ -1004,6 +1006,7 @@ public class SubmitWindow {
         return new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
+                checkVariables = true;
                 setAllValuesAsString();
                 handleStartAt();
                 enableValidation(true);
@@ -1221,6 +1224,7 @@ public class SubmitWindow {
         return new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
+                checkVariables = false;
                 setAllValuesAsString();
                 enableValidation(false);
                 handleRadioButton();
@@ -1232,7 +1236,9 @@ public class SubmitWindow {
                 variablesActualForm.addSubmitCompleteHandler(new SubmitCompleteHandler() {
                     @Override
                     public void onSubmitComplete(SubmitCompleteEvent event) {
-                        handleJobSubmission(event);
+                        if (!checkVariables) {
+                            handleJobSubmission(event);
+                        }
                     }
 
                     private void handleJobSubmission(SubmitCompleteEvent event) {


### PR DESCRIPTION
When clicking on Submit, a SubmitCompleteHandler is added to the variables form and when clicking on Check, another SubmitCompleteHandler is added to the variables form.
This is why when we click on Submit and then on Check buttons, both of the SubmitCompleteHandler events are executed.
I have added a flag to prevent this behavior. 