### PR TITLE
Use two different configuration properties for catalog urls

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/CatalogUrlRmClientBuilder.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/nodesource/serialization/CatalogUrlRmClientBuilder.java
@@ -34,7 +34,7 @@ public class CatalogUrlRmClientBuilder {
 
     public String getCatalogUrl() {
         if (this.catalogUrl == null) {
-            String catalogUrlFromConfig = RMConfig.get().getCatalogUrl();
+            String catalogUrlFromConfig = RMConfig.get().getCatalogPublicUrl();
 
             if (catalogUrlFromConfig == null || catalogUrlFromConfig.isEmpty()) {
                 this.catalogUrl = com.google.gwt.user.client.Window.Location.getHref().replace("/rm/", "/") + "catalog";

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/nodesource/serialization/export/ExportToCatalogServlet.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/server/nodesource/serialization/export/ExportToCatalogServlet.java
@@ -77,7 +77,8 @@ public class ExportToCatalogServlet extends HttpServlet {
                                                          catalogObjectAction.getCatalogObjectName(),
                                                          catalogObjectAction.getCommitMessage(),
                                                          catalogObjectAction.getCatalogObjectJsonFile(),
-                                                         catalogObjectAction.getProjectName());
+                                                         catalogObjectAction.getProjectName(),
+                                                         null);
                 LOGGER.info("Post new revision of catalog object " + catalogObjectAction.getCatalogObjectName() +
                             " in bucket " + catalogObjectAction.getBucketName());
             } else {
@@ -89,7 +90,8 @@ public class ExportToCatalogServlet extends HttpServlet {
                                                          catalogObjectAction.getObjectContentType(),
                                                          catalogObjectAction.getCatalogObjectJsonFile(),
                                                          catalogObjectAction.getCatalogObjectName(),
-                                                         catalogObjectAction.getProjectName());
+                                                         catalogObjectAction.getProjectName(),
+                                                         null);
                 LOGGER.info("Post new catalog object " + catalogObjectAction.getCatalogObjectName() + " in bucket " +
                             catalogObjectAction.getBucketName());
             }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/RMConfig.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/RMConfig.java
@@ -127,6 +127,8 @@ public class RMConfig extends Config {
     /** Workflow Catalog URL **/
     public static final String CATALOG_URL = "rm.catalog.url";
 
+    public static final String CATALOG_PUBLIC_URL = "rm.catalog.public.url";
+
     private static RMConfig instance = null;
 
     /**
@@ -266,6 +268,13 @@ public class RMConfig extends Config {
      */
     public String getCatalogUrl() {
         return properties.get(CATALOG_URL);
+    }
+
+    /**
+     * @return the catalog url or null if none has been defined
+     */
+    public String getCatalogPublicUrl() {
+        return properties.get(CATALOG_PUBLIC_URL);
     }
 
     public Optional<String> getHelpLink(String pluginName) {

--- a/rm-portal/src/main/webapp/rm.conf
+++ b/rm-portal/src/main/webapp/rm.conf
@@ -18,5 +18,9 @@ rm.monitoring.period=15000
 # the default protocol used for monitoring is proactive, this is to prevent firewall issues.
 rm.monitoring.protocol=proactive
 
-# must be accessible remotely with the public address or hostname of the catalog
-#rm.catalog.url=http://localhost:8080/catalog
+# catalog REST API url
+rm.catalog.url=http://localhost:8080/catalog
+
+
+# catalog REST API public url. Set this property when the ProActive server is behind a reverse proxy and issues appear. The configured url should be the one seen by the portal users.
+#rm.catalog.public.url=http://localhost:8080/catalog

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/CatalogUrlSchedulerClientBuilder.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/CatalogUrlSchedulerClientBuilder.java
@@ -34,7 +34,7 @@ public class CatalogUrlSchedulerClientBuilder {
 
     public String getCatalogUrl() {
         if (this.catalogUrl == null) {
-            String catalogUrlFromConfig = SchedulerConfig.get().getCatalogUrl();
+            String catalogUrlFromConfig = SchedulerConfig.get().getCatalogPublicUrl();
 
             if (catalogUrlFromConfig == null || catalogUrlFromConfig.isEmpty()) {
                 this.catalogUrl = com.google.gwt.user.client.Window.Location.getHref().replace("/scheduler/", "/") +

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -112,6 +112,8 @@ public class SchedulerConfig extends Config {
     /** Workflow Catalog URL **/
     public static final String CATALOG_URL = "sched.catalog.url";
 
+    public static final String CATALOG_PUBLIC_URL = "sched.catalog.public.url";
+
     private static SchedulerConfig instance = null;
 
     /**
@@ -290,6 +292,13 @@ public class SchedulerConfig extends Config {
      */
     public String getCatalogUrl() {
         return properties.get(CATALOG_URL);
+    }
+
+    /**
+     * @return the catalog public url or null if none has been defined
+     */
+    public String getCatalogPublicUrl() {
+        return properties.get(CATALOG_PUBLIC_URL);
     }
 
     /**

--- a/scheduler-portal/src/main/webapp/scheduler.conf
+++ b/scheduler-portal/src/main/webapp/scheduler.conf
@@ -4,8 +4,11 @@ sched.rest.url=http://localhost:8080/rest
 # job-planner REST API url
 jobplanner.rest.url=http://localhost:8080/job-planner/planned_jobs
 
-# must be accessible remotely with the public address or hostname of the catalog
-#sched.catalog.url=http://localhost:8080/catalog
+# catalog REST API url
+sched.catalog.url=http://localhost:8080/catalog
+
+# catalog REST API public url. Set this property when the ProActive server is behind a reverse proxy and issues appear. The configured url should be the one seen by the portal users.
+#sched.catalog.public.url=http://localhost:8080/catalog
 
 # define whether hostname checking is performed or not when HTTPS
 # is used to communicate with the REST API


### PR DESCRIPTION
 - the server-side configuration must be differentiated from the client-side (browser) configuration.
 - server-side configuration is always set, while client-side is optional
 - fix parameters of catalog-client due to the last client rebuild