### PR TITLE
Fix RM portal NS display:

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/InfoView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/InfoView.java
@@ -378,13 +378,12 @@ public class InfoView implements NodeSelectedListener, NodesListener {
             numNodes += h.getNodes().size();
         }
 
-        String infrastructure = null;
-        String infrastructureParams = null;
-        String policy = null;
-        String policyParams = null;
+        String infrastructure = "";
+        String infrastructureParams = "";
+        String policy = "";
+        String policyParams = "";
 
         String[] NSPolicyAndInfra = ns.getSourceDescription().split("Infrastructure: |, Policy: ");
-
         if (NSPolicyAndInfra.length == 3) {
             infrastructure = NSPolicyAndInfra[1].trim();
             policy = NSPolicyAndInfra[2].trim();
@@ -394,15 +393,15 @@ public class InfoView implements NodeSelectedListener, NodesListener {
             policy = NSPolicyAndInfra[0].trim();
         }
 
-        if (infrastructure != null) {
-            String[] result = splitAndExtractNameAndParamsFromDescription(infrastructure);
-            infrastructure = result[0];
+        String[] result = splitAndExtractNameAndParamsFromDescription(infrastructure);
+        infrastructure = result[0];
+        if (result.length > 1) {
             infrastructureParams = result[1];
         }
 
-        if (policy != null) {
-            String[] result = splitAndExtractNameAndParamsFromDescription(policy);
-            policy = result[0];
+        result = splitAndExtractNameAndParamsFromDescription(policy);
+        policy = result[0];
+        if (result.length > 1) {
             policyParams = result[1];
         }
 
@@ -414,6 +413,7 @@ public class InfoView implements NodeSelectedListener, NodesListener {
         dv.setAttribute("nodeProvider", ns.getNodeSourceAdmin());
         dv.setAttribute("nodes", numNodes);
         dv.setAttribute("hosts", ns.getHosts().size());
+
         this.nsDetails.setData(new DetailViewerRecord[] { dv });
 
         // Update additional information -----------

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -67,9 +67,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
 
     public static final String POLICY = ", Policy: ";
 
-    public static final String USER_ACCESS_TYPE_ = "user access type ";
-
-    public static final String PROVIDER_ACCESS_TYPE_ = ", provider access type ";
+    public static final String USER_ACCESS_TYPE_ = "userAccessType: ";
 
     public static final String INFRASTRUCTURE_FIELD = "Infrastructure";
 
@@ -216,7 +214,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             policy = policy.substring(0, policy.indexOf(USER_ACCESS_TYPE_));
             policy = policy.replace(POLICY_FIELD, "");
             policy = beautifyName(policy);
-            access = access.substring(0, access.indexOf(PROVIDER_ACCESS_TYPE_));
+            access = access.split(", ", 2)[0];
         }
 
         public String getInfrastructure() {

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
@@ -66,7 +66,7 @@ public class TreeViewTest {
     public void testRemoveNodeSource() {
         final List<NodeSource> nodeSourceList = IntStream.range(0, 2).mapToObj(i -> {
             final NodeSource nodeSource = new NodeSource("sourceName" + i,
-                                                         "Infrastructure: Test, Policy: Test Policy user access type [ALL], provider access type [ALL]",
+                                                         "Infrastructure: AzureInfrastructure, Policy: TestPolicy userAccessType: [ALL], providerAccessType: [ALL]",
                                                          new LinkedHashMap<>(),
                                                          "",
                                                          "undeployed",


### PR DESCRIPTION
- Fix potential out of bound exception if infrastructure or policy has no parameters
- Fix how infrastructure, policy and user acess is parsed to be displayed in the NS definition list

![image](https://github.com/ow2-proactive/scheduling-portal/assets/53172400/d63ee98b-3079-4fb3-a227-48ec76533421)

