### PR TITLE
Fix node source icon compact view bug

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NodeSource.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NodeSource.java
@@ -146,6 +146,14 @@ public class NodeSource {
         return "NODESOURCE_DEFINED".equalsIgnoreCase(eventType);
     }
 
+    public boolean isUndeployed() {
+        return "NODESOURCE_SHUTDOWN".equalsIgnoreCase(eventType);
+    }
+
+    public boolean isDeployed() {
+        return "NODESOURCE_CREATED".equalsIgnoreCase(eventType);
+    }
+
     public boolean isChanged() {
         return !isAdded() && !isRemoved();
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -504,15 +504,15 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             for (NodeSource nodeSource : nodeSources) {
                 if (nodeSource.isRemoved()) {
                     removeNodeSource(nodeSource);
-                    continue;
+                } else {
+                    if (nodeSource.isUndeployed() || nodeSource.isDeployed()) {
+                        removeNodeSource(nodeSource);
+                    }
+                    addNodeSourceIfNotExists(nodeSource);
+                    updateNodeSourceDescriptionIfChanged(nodeSource);
+                    updateNodeSourceDisplayedNumberOfNodesIfChanged(nodeSource);
+                    changeNodeSourceStatusIfChanged(nodeSource);
                 }
-                if (nodeSource.isUndeployed() || nodeSource.isDeployed()) {
-                    removeNodeSource(nodeSource);
-                }
-                addNodeSourceIfNotExists(nodeSource);
-                updateNodeSourceDescriptionIfChanged(nodeSource);
-                updateNodeSourceDisplayedNumberOfNodesIfChanged(nodeSource);
-                changeNodeSourceStatusIfChanged(nodeSource);
             }
         }
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -499,18 +499,20 @@ public class TreeView implements NodesListener, NodeSelectedListener {
     }
 
     void processNodeSources(List<NodeSource> nodeSources, List<Node> nodes) {
-
         addNodesToNodeSources(nodeSources, nodes);
         if (!nodeSources.isEmpty()) {
             for (NodeSource nodeSource : nodeSources) {
                 if (nodeSource.isRemoved()) {
                     removeNodeSource(nodeSource);
-                } else {
-                    addNodeSourceIfNotExists(nodeSource);
-                    updateNodeSourceDescriptionIfChanged(nodeSource);
-                    updateNodeSourceDisplayedNumberOfNodesIfChanged(nodeSource);
-                    changeNodeSourceStatusIfChanged(nodeSource);
+                    continue;
                 }
+                if (nodeSource.isUndeployed() || nodeSource.isDeployed()) {
+                    removeNodeSource(nodeSource);
+                }
+                addNodeSourceIfNotExists(nodeSource);
+                updateNodeSourceDescriptionIfChanged(nodeSource);
+                updateNodeSourceDisplayedNumberOfNodesIfChanged(nodeSource);
+                changeNodeSourceStatusIfChanged(nodeSource);
             }
         }
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
@@ -189,10 +189,6 @@ public class CompactView implements NodesListener, NodeSelectedListener {
      */
     @Override
     public void updateByDelta(List<NodeSource> nodeSources, List<Node> nodes) {
-        /* first call : create the components */
-        if (nodeSourceAdded(nodeSources)) {
-            treeView.sortCompactView(this);
-        }
         List<NodeSource> currentNodeSources = nodeSourceDeleted(nodeSources) ? nodeSources
                                                                              : getSortedNodeSourceList(nodeSources);
         if (this.compactPanel == null) {

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
@@ -227,10 +227,6 @@ public class CompactView implements NodesListener, NodeSelectedListener {
         return nodeSources == null || nodeSources.isEmpty() || nodeSources.stream().allMatch(NodeSource::isRemoved);
     }
 
-    private boolean nodeSourceAdded(List<NodeSource> nodeSources) {
-        return nodeSources != null && nodeSources.size() == 1 && nodeSources.get(0).getDeploying().size() != 0;
-    }
-
     private void updateCompactPanel(List<NodeSource> nodeSources, List<Node> nodes) {
         processNodeSources(compactPanel, nodeSources);
         processNodes(compactPanel, nodes);


### PR DESCRIPTION
Bug: When a nodesource is undeployed and you click on a column (ie #Nodes) to sort the nodesources, the undeployed node source icon is switched back to the deployed icon in the compact view.

---

Fix: Remove NodeSource from Tree when it is deployed or undeployed so that the NS is recreated thus saving the correct NS state.
No need to manually call sortCompactView from Tree.