### PR TITLE
Fix RM portal autorefresh bug. 

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
@@ -388,13 +388,19 @@ public class RMController extends Controller implements UncaughtExceptionHandler
         this.updater = new Timer() {
             @Override
             public void run() {
-
-                if (!localSessionNum.equals(Cookies.getCookie(LOCAL_SESSION_COOKIE))) {
-                    teardown("Duplicate session detected!<br>" +
-                             "Another tab or window in this browser is accessing this page.");
+                try {
+                    if (!localSessionNum.equals(Cookies.getCookie(LOCAL_SESSION_COOKIE))) {
+                        teardown("Duplicate session detected!<br>" +
+                                 "Another tab or window in this browser is accessing this page.");
+                    }
+                    fetchRMMonitoring();
+                } catch (Exception e) {
+                    if (e.getStackTrace().length == 0) {
+                        e.fillInStackTrace();
+                    }
+                    LogModel.getInstance()
+                            .logImportantMessage("Exception thrown while Autorefresh fetch RMMonitoring" + e);
                 }
-                fetchRMMonitoring();
-
             }
         };
         this.updater.schedule(RMConfig.get().getClientRefreshTime());
@@ -402,7 +408,15 @@ public class RMController extends Controller implements UncaughtExceptionHandler
         this.statsUpdater = new Timer() {
             @Override
             public void run() {
-                fetchStatHistory();
+                try {
+                    fetchStatHistory();
+                } catch (Exception e) {
+                    if (e.getStackTrace().length == 0) {
+                        e.fillInStackTrace();
+                    }
+                    LogModel.getInstance()
+                            .logImportantMessage("Exception thrown while Autorefresh fetch StatHistory." + e);
+                }
             }
         };
         this.statsUpdater.scheduleRepeating(RMConfig.get().getStatisticsRefreshTime());
@@ -643,7 +657,16 @@ public class RMController extends Controller implements UncaughtExceptionHandler
 
         model.setNodes(newNodeSources);
         model.nodesUpdate(newNodeSources);
-        model.updateByDelta(nodeSourceList, nodeList);
+        try {
+            model.updateByDelta(nodeSourceList, nodeList);
+        } catch (Exception e) {
+            if (e.getStackTrace().length == 0) {
+                e.fillInStackTrace();
+            }
+            LogModel.getInstance()
+                    .logImportantMessage("An Error occurred while the Controller tried to update NodeSources after HTTP request");
+            throw e;
+        }
 
         recalculatePhysicalVirtualHosts();
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
@@ -388,11 +388,11 @@ public class RMController extends Controller implements UncaughtExceptionHandler
         this.updater = new Timer() {
             @Override
             public void run() {
+                if (!localSessionNum.equals(Cookies.getCookie(LOCAL_SESSION_COOKIE))) {
+                    teardown("Duplicate session detected!<br>" +
+                             "Another tab or window in this browser is accessing this page.");
+                }
                 try {
-                    if (!localSessionNum.equals(Cookies.getCookie(LOCAL_SESSION_COOKIE))) {
-                        teardown("Duplicate session detected!<br>" +
-                                 "Another tab or window in this browser is accessing this page.");
-                    }
                     fetchRMMonitoring();
                 } catch (Exception e) {
                     if (e.getStackTrace().length == 0) {

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -563,7 +563,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             if (nodeSource != null) {
                 removeDeployingNode(nodeSource, node);
             }
-            if (!node.isDeployingNode() && !tree.hasChildren(parent)) { // thus this node has a host, which might be removed
+            if (!node.isDeployingNode() && parent != null && tree.contains(parent) && !tree.hasChildren(parent)) { // thus this node has a host, which might be removed
                 tree.remove(parent);
                 currentTreeNodes.remove(parent.getAttribute(NODE_ID));
             }


### PR DESCRIPTION
- Null check the treenode before removing it as it can be already removed by a parallel thread initiated by the rm.getMonitoring() callBack.
- Add some exception catch, especially in the Timer's run() to avoid breaking the autorefresh.