### PR TITLE
Add null check on the node object too for same reason, might be already deleted by getModel callback exec.

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -563,7 +563,8 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             if (nodeSource != null) {
                 removeDeployingNode(nodeSource, node);
             }
-            if (!node.isDeployingNode() && parent != null && tree.contains(parent) && !tree.hasChildren(parent)) { // thus this node has a host, which might be removed
+            if (node != null && parent != null && !node.isDeployingNode() && tree.contains(parent) &&
+                !tree.hasChildren(parent)) { // thus this node has a host, which might be removed
                 tree.remove(parent);
                 currentTreeNodes.remove(parent.getAttribute(NODE_ID));
             }


### PR DESCRIPTION
Node object might be already deleted at this point. NullCheck the object to prevent Nullpointer