### PR TITLE
Fix NS and host remains in TreeView when it should be removed (scale down to 0).

### DIFF
--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
@@ -87,10 +87,10 @@ public class TreeViewTest {
         treeView.processNodeSources(nodeSourceList, nodeList);
 
         verify(treeView.tree, times(2)).add(any(TreeNode.class), any(TreeNode.class));
-
+        when(treeView.tree.getAllNodes()).thenReturn(new TreeNode[0]);
         treeView.processNodes(nodeList);
 
-        verify(treeView.tree, times(33)).add(any(TreeNode.class), any(TreeNode.class));
+        verify(treeView.tree, times(34)).add(any(TreeNode.class), any(TreeNode.class));
 
         assertEquals(33, treeView.currentTreeNodes.size());
 
@@ -98,9 +98,9 @@ public class TreeViewTest {
         nodeSource.setEventType("NODESOURCE_REMOVED");
 
         ArgumentCaptor<TreeNode> captor = ArgumentCaptor.forClass(TreeNode.class);
-        verify(treeView.tree, times(33)).add(captor.capture(), any(TreeNode.class));
+        verify(treeView.tree, times(34)).add(captor.capture(), any(TreeNode.class));
 
-        assertEquals(33, captor.getAllValues().size());
+        assertEquals(34, captor.getAllValues().size());
 
         final List<TreeNode> allValues = captor.getAllValues();
         allValues.remove(0);


### PR DESCRIPTION
- When a node is removed, we check if it was the last one. If yes, then we remove the host.
- When the Tree is empty and the first node becomes available, we create the NS node before adding the host.
Thats because when the node goes from Deployed to Free, the NS TreeNode has been removed due to Hide empty NS being true