### PR TITLE
Hide empty ns store in session and fix automatic sorting

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -151,6 +151,8 @@ public class RMPage implements LogListener {
 
     private Label errorLabel = null;
 
+    public static final String NOT_EMPTY_NS_VIEW = "not.empty.ns.view";
+
     RMPage(RMController controller) {
         this.controller = controller;
         LogModel.getInstance().addLogListener(this);
@@ -215,8 +217,11 @@ public class RMPage implements LogListener {
         checkBoxes.setItems(c1);
 
         final CheckboxItem hideEmpty = new CheckboxItem("emptyNs", "Hide Empty Node Sources");
-        hideEmpty.setValue(false);
-        hideEmpty.addChangedHandler(event -> treeView.setNotEmptyNsView(hideEmpty.getValueAsBoolean()));
+        hideEmpty.setValue(Boolean.parseBoolean(Settings.get().getSetting(NOT_EMPTY_NS_VIEW)));
+        hideEmpty.addChangedHandler(event -> {
+            Settings.get().setSetting(NOT_EMPTY_NS_VIEW, String.valueOf(hideEmpty.getValueAsBoolean()));
+            treeView.setNotEmptyNsView(hideEmpty.getValueAsBoolean());
+        });
 
         DynamicForm hideEmptyForm = new DynamicForm();
         hideEmptyForm.setNumCols(8);

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -793,7 +793,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
                                               .collect(Collectors.toList()));
         }
         if (!hideEmptyNs) {
-            treeGrid.sort();
+            getTreeGrid().sort();
             sortCompactView(compactView, currentNodeSources);
         }
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -621,7 +621,9 @@ public class TreeView implements NodesListener, NodeSelectedListener {
                     if (nodeSource.isShutdown() || nodeSource.isDeployed()) {
                         removeNodeSource(nodeSource);
                     }
-                    addNodeSourceIfNotExists(nodeSource);
+                    boolean newNodeSource = !currentTreeNodes.containsKey(nodeSource.getSourceName());
+                    addNodeSourceIfNotExists(nodeSource, newNodeSource);
+                    sortTreeIfNewNodeSource(nodeSource, newNodeSource, nodeSources.size());
                     updateNodeSourceDescriptionIfChanged(nodeSource);
                     updateNodeSourceDisplayedNumberOfNodesIfChanged(nodeSource);
                     changeNodeSourceStatusIfChanged(nodeSource);
@@ -673,8 +675,14 @@ public class TreeView implements NodesListener, NodeSelectedListener {
         }
     }
 
-    void addNodeSourceIfNotExists(NodeSource nodeSource) {
-        if (!currentTreeNodes.containsKey(nodeSource.getSourceName())) {
+    void sortTreeIfNewNodeSource(NodeSource nodeSource, boolean newNodeSource, int numberOfNs) {
+        if (numberOfNs == 1 && newNodeSource) {
+            sortNotEmptyNsView(nodeSource);
+        }
+    }
+
+    void addNodeSourceIfNotExists(NodeSource nodeSource, boolean newNodeSource) {
+        if (newNodeSource) {
             TNS nsTreeNode = new TNS(nodeSource.getSourceName(), nodeSource);
             nsTreeNode.setIcon(nodeSource.getIcon());
             tree.add(nsTreeNode, this.tree.getRoot());
@@ -693,6 +701,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             currentTreeNodes.put(nodeSource.getSourceName(), currentNs);
             currentNodeSources.remove(nodeSource);
             currentNodeSources.add(nodeSource);
+            sortNotEmptyNsView(nodeSource);
         }
         if (!currentNs.getAttribute(POLICY_FIELD).equals(nodeSourceDisplayedDescription.getPolicy())) {
             currentNs.setAttribute(POLICY_FIELD, nodeSourceDisplayedDescription.getPolicy());
@@ -706,6 +715,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             currentTreeNodes.put(nodeSource.getSourceName(), currentNs);
             currentNodeSources.remove(nodeSource);
             currentNodeSources.add(nodeSource);
+            sortNotEmptyNsView(nodeSource);
         }
 
     }
@@ -727,6 +737,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
             currentTreeNodes.put(nodeSource.getSourceName(), currentNs);
             currentNodeSources.remove(nodeSource);
             currentNodeSources.add(nodeSource);
+            sortNotEmptyNsView(nodeSource);
         }
     }
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
@@ -201,6 +201,7 @@ public class CompactView implements NodesListener, NodeSelectedListener {
         updateCompactPanel(currentNodeSources, nodes);
         updateMyNodesCompactPanel(currentNodeSources, nodes);
         updateSelection();
+        treeView.restoreLocalStorageView();
     }
 
     private void updateSelection() {

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
@@ -27,6 +27,7 @@ package org.ow2.proactive_grid_cloud_portal.rm.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -43,9 +45,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.ow2.proactive_grid_cloud_portal.rm.client.monitoring.views.compact.CompactView;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.smartgwt.client.widgets.tree.Tree;
+import com.smartgwt.client.widgets.tree.TreeGrid;
 import com.smartgwt.client.widgets.tree.TreeNode;
 
 
@@ -83,7 +89,8 @@ public class TreeViewTest {
             node.setNodeState(NodeState.FREE);
             return node;
         }).collect(Collectors.toList());
-
+        when(treeView.getTreeGrid()).thenReturn(new TreeGrid());
+        doNothing().when(treeView).sortCompactView(any(CompactView.class), any(LinkedList.class));
         treeView.processNodeSources(nodeSourceList, nodeList);
 
         verify(treeView.tree, times(2)).add(any(TreeNode.class), any(TreeNode.class));

--- a/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
+++ b/rm-portal/src/test/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeViewTest.java
@@ -45,8 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
 import org.ow2.proactive_grid_cloud_portal.rm.client.monitoring.views.compact.CompactView;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;


### PR DESCRIPTION
- Hide empty NS option should be stored in session
- Order by nodes and then scale up a Ns, you will see that the sort is not applied
- NS dissapears when Log out and Log back in (hide empty NS ticked)
- Duplicate icons in compact view