### PR TITLE
Fix incorrect portal buttons URLs in RM & Scheduler portal

### DIFF
--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/AboutWindow.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/AboutWindow.java
@@ -52,18 +52,18 @@ public class AboutWindow {
     /**
      * Default constructor
      */
-    public AboutWindow() {
-        this.build();
+    public AboutWindow(String restUrl) {
+        this.build(restUrl);
     }
 
-    private void build() {
+    private void build(String restUrl) {
         HLayout pane = new HLayout();
         pane.setWidth100();
         pane.setHeight(240);
         pane.setBackgroundColor("#ffffff");
 
         HTMLPane text = new HTMLPane();
-        text.setContents(Config.get().getAboutText());
+        text.setContents(Config.get().getAboutText(restUrl));
         text.setWidth100();
         text.setStyleName("paddingLeftAndRight");
 

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
@@ -25,7 +25,8 @@
  */
 package org.ow2.proactive_grid_cloud_portal.common.client;
 
-import com.google.gwt.core.client.GWT;
+import org.ow2.proactive_grid_cloud_portal.common.shared.Config;
+
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
 import com.smartgwt.client.util.SC;
@@ -34,10 +35,6 @@ import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 
 public class ToolButtonsRender {
     private static final String GREY_BUTTON_BORDER = "1px solid #858585";
-
-    private static final String BASE_RM_MODULE_PATH = "/rm/";
-
-    private static final String BASE_SCHEDULER_MODULE_PATH = "/scheduler/";
 
     public ToolStripButton getSchedulerLinkButton() {
         return getToolStripButton(Images.instance.scheduler_30(), "Scheduling & Orchestration", "scheduler/");
@@ -106,7 +103,7 @@ public class ToolButtonsRender {
     private ToolStripButton getToolStripButtonWithoutBorder(ImageResource imageResource, String title,
             final String url) {
         ToolStripButton toolStripButton = getSimpleToolStripButton(imageResource, title);
-        String absoluteUrl = getUrlFromRelativePath(url);
+        String absoluteUrl = Config.get().getAbsoluteUrlWithPath(url);
         toolStripButton.addClickHandler(event -> Window.open(absoluteUrl, absoluteUrl, ""));
         return toolStripButton;
     }
@@ -116,9 +113,5 @@ public class ToolButtonsRender {
         toolStripButton.setIcon(imageResource.getSafeUri().asString());
         toolStripButton.setIconSize(25);
         return toolStripButton;
-    }
-
-    private String getUrlFromRelativePath(String path) {
-        return GWT.getHostPageBaseURL().replace(BASE_RM_MODULE_PATH, "").replace(BASE_SCHEDULER_MODULE_PATH, "") + path;
     }
 }

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
@@ -35,7 +35,9 @@ import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 public class ToolButtonsRender {
     private static final String GREY_BUTTON_BORDER = "1px solid #858585";
 
-    private static final String BASE_MODULE_PATH = "/rm";
+    private static final String BASE_RM_MODULE_PATH = "/rm/";
+
+    private static final String BASE_SCHEDULER_MODULE_PATH = "/scheduler/";
 
     public ToolStripButton getSchedulerLinkButton() {
         return getToolStripButton(Images.instance.scheduler_30(), "Scheduling & Orchestration", "scheduler/");
@@ -44,29 +46,29 @@ public class ToolButtonsRender {
     public ToolStripButton getSchedulerHighlightedLinkButton() {
         return getToolStripButtonHighlighted(Images.instance.scheduler_30(),
                                              "Scheduling & Orchestration",
-                                             "scheduler/");
+                                             "/scheduler/");
     }
 
     public ToolStripButton getStudioLinkButton() {
         ImageResource imageResource = Images.instance.studio_30();
         String title = "Workflow Studio";
-        String url = "studio/#workflows";
+        String url = "/studio/#workflows";
 
         return getToolStripButton(imageResource, title, url);
     }
 
     public ToolStripButton getResourceManagerLinkButton() {
-        return getToolStripButton(Images.instance.rm_30(), "Resource Manager", "rm/");
+        return getToolStripButton(Images.instance.rm_30(), "Resource Manager", "/rm/");
     }
 
     public ToolStripButton getResourceManagerHighlightedLinkButton() {
-        return getToolStripButtonHighlighted(Images.instance.rm_30(), "Resource Manager", "rm/");
+        return getToolStripButtonHighlighted(Images.instance.rm_30(), "Resource Manager", "/rm/");
     }
 
     public ToolStripButton getAutomationDashboardLinkButton() {
         return getToolStripButton(Images.instance.automation_dashboard_30(),
                                   "Automation Dashboard",
-                                  "automation-dashboard/#/workflow-execution");
+                                  "/automation-dashboard/#/workflow-execution");
     }
 
     public ToolStripButton getLogoutButton(String login, final Controller controller) {
@@ -104,8 +106,7 @@ public class ToolButtonsRender {
     private ToolStripButton getToolStripButtonWithoutBorder(ImageResource imageResource, String title,
             final String url) {
         ToolStripButton toolStripButton = getSimpleToolStripButton(imageResource, title);
-        String baseUrl = GWT.getHostPageBaseURL().replace(BASE_MODULE_PATH, "");
-        String absoluteUrl = baseUrl + url;
+        String absoluteUrl = getUrlFromRelativePath(url);
         toolStripButton.addClickHandler(event -> Window.open(absoluteUrl, absoluteUrl, ""));
         return toolStripButton;
     }
@@ -115,5 +116,11 @@ public class ToolButtonsRender {
         toolStripButton.setIcon(imageResource.getSafeUri().asString());
         toolStripButton.setIconSize(25);
         return toolStripButton;
+    }
+
+    private String getUrlFromRelativePath(String path) {
+        String baseUrl = GWT.getHostPageBaseURL().replace(BASE_RM_MODULE_PATH, "").replace(BASE_SCHEDULER_MODULE_PATH,
+                                                                                           "");
+        return baseUrl + path;
     }
 }

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
@@ -119,8 +119,6 @@ public class ToolButtonsRender {
     }
 
     private String getUrlFromRelativePath(String path) {
-        String baseUrl = GWT.getHostPageBaseURL().replace(BASE_RM_MODULE_PATH, "").replace(BASE_SCHEDULER_MODULE_PATH,
-                                                                                           "");
-        return baseUrl + path;
+        return GWT.getHostPageBaseURL().replace(BASE_RM_MODULE_PATH, "").replace(BASE_SCHEDULER_MODULE_PATH, "") + path;
     }
 }

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/client/ToolButtonsRender.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive_grid_cloud_portal.common.client;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
 import com.smartgwt.client.util.SC;
@@ -34,36 +35,38 @@ import com.smartgwt.client.widgets.toolbar.ToolStripButton;
 public class ToolButtonsRender {
     private static final String GREY_BUTTON_BORDER = "1px solid #858585";
 
+    private static final String BASE_MODULE_PATH = "/rm";
+
     public ToolStripButton getSchedulerLinkButton() {
-        return getToolStripButton(Images.instance.scheduler_30(), "Scheduling & Orchestration", "/scheduler/");
+        return getToolStripButton(Images.instance.scheduler_30(), "Scheduling & Orchestration", "scheduler/");
     }
 
     public ToolStripButton getSchedulerHighlightedLinkButton() {
         return getToolStripButtonHighlighted(Images.instance.scheduler_30(),
                                              "Scheduling & Orchestration",
-                                             "/scheduler/");
+                                             "scheduler/");
     }
 
     public ToolStripButton getStudioLinkButton() {
         ImageResource imageResource = Images.instance.studio_30();
         String title = "Workflow Studio";
-        String url = "/studio/";
+        String url = "studio/#workflows";
 
         return getToolStripButton(imageResource, title, url);
     }
 
     public ToolStripButton getResourceManagerLinkButton() {
-        return getToolStripButton(Images.instance.rm_30(), "Resource Manager", "/rm/");
+        return getToolStripButton(Images.instance.rm_30(), "Resource Manager", "rm/");
     }
 
     public ToolStripButton getResourceManagerHighlightedLinkButton() {
-        return getToolStripButtonHighlighted(Images.instance.rm_30(), "Resource Manager", "/rm/");
+        return getToolStripButtonHighlighted(Images.instance.rm_30(), "Resource Manager", "rm/");
     }
 
     public ToolStripButton getAutomationDashboardLinkButton() {
         return getToolStripButton(Images.instance.automation_dashboard_30(),
                                   "Automation Dashboard",
-                                  "/automation-dashboard/");
+                                  "automation-dashboard/#/workflow-execution");
     }
 
     public ToolStripButton getLogoutButton(String login, final Controller controller) {
@@ -101,8 +104,9 @@ public class ToolButtonsRender {
     private ToolStripButton getToolStripButtonWithoutBorder(ImageResource imageResource, String title,
             final String url) {
         ToolStripButton toolStripButton = getSimpleToolStripButton(imageResource, title);
-
-        toolStripButton.addClickHandler(event -> Window.open(url, url, ""));
+        String baseUrl = GWT.getHostPageBaseURL().replace(BASE_MODULE_PATH, "");
+        String absoluteUrl = baseUrl + url;
+        toolStripButton.addClickHandler(event -> Window.open(absoluteUrl, absoluteUrl, ""));
         return toolStripButton;
     }
 

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/shared/Config.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/shared/Config.java
@@ -29,7 +29,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.i18n.shared.DefaultDateTimeFormatInfo;
 
@@ -141,11 +140,7 @@ public abstract class Config {
      * @return the {@link #getRestPublicUrlIfDefinedOrOverridden()} or guessed from current location if not set
      */
     public String getRestPublicUrlOrGuessRestUrl() {
-        String restPublicUrl = getRestPublicUrlIfDefinedOrOverridden();
-        if (restPublicUrl == null || restPublicUrl.isEmpty()) {
-            return GWT.getHostPageBaseURL().replace("rm/", "").replace("scheduler/", "") + "rest";
-        }
-        return restPublicUrl;
+        return getRestPublicUrlIfDefinedOrOverridden();
     }
 
     /**
@@ -172,6 +167,11 @@ public abstract class Config {
      * @return URL of the service to GET for the MOTD
      */
     public abstract String getMotdUrl();
+
+    /**
+     * @return An Absolute URL of the server with the appended path
+     */
+    public abstract String getAbsoluteUrlWithPath(String path);
 
     public String getAboutText(String restUrl) {
         return fillTemplate(properties.get(ABOUT), restUrl);

--- a/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/shared/Config.java
+++ b/common-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/common/shared/Config.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.i18n.shared.DefaultDateTimeFormatInfo;
 
@@ -142,11 +143,7 @@ public abstract class Config {
     public String getRestPublicUrlOrGuessRestUrl() {
         String restPublicUrl = getRestPublicUrlIfDefinedOrOverridden();
         if (restPublicUrl == null || restPublicUrl.isEmpty()) {
-            String restUrlFromCurrentLocation = com.google.gwt.user.client.Window.Location.getHref();
-            restUrlFromCurrentLocation = restUrlFromCurrentLocation.replace(com.google.gwt.user.client.Window.Location.getPath(),
-                                                                            "");
-            restUrlFromCurrentLocation += "/rest";
-            return restUrlFromCurrentLocation;
+            return GWT.getHostPageBaseURL().replace("rm/", "").replace("scheduler/", "") + "rest";
         }
         return restPublicUrl;
     }
@@ -176,8 +173,8 @@ public abstract class Config {
      */
     public abstract String getMotdUrl();
 
-    public String getAboutText() {
-        return fillTemplate(properties.get(ABOUT));
+    public String getAboutText(String restUrl) {
+        return fillTemplate(properties.get(ABOUT), restUrl);
     }
 
     private static final String ABOUT = "about";
@@ -205,10 +202,10 @@ public abstract class Config {
         return dateTimeFormat.format(new Date());
     }
 
-    private String fillTemplate(String template) {
+    private String fillTemplate(String template, String restUrl) {
         return template.replace("@application_name@", getApplicationName())
                        .replace("@version@", getVersion())
-                       .replace("@rest_public_url@", getRestPublicUrlOrGuessRestUrl())
+                       .replace("@rest_public_url@", restUrl)
                        .replace("@rest_version@", getRestVersion())
                        .replace("@application_version@", getApplicationVersion());
     }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/InfoView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/InfoView.java
@@ -26,7 +26,6 @@
 package org.ow2.proactive_grid_cloud_portal.rm.client;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/MonitoringView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/MonitoringView.java
@@ -25,7 +25,7 @@
  */
 package org.ow2.proactive_grid_cloud_portal.rm.client;
 
-import static org.ow2.proactive_grid_cloud_portal.rm.client.RMListeners.*;
+import static org.ow2.proactive_grid_cloud_portal.rm.client.RMListeners.NodesListener;
 
 import java.util.Map;
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NodeSourceStatus.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/NodeSourceStatus.java
@@ -27,8 +27,6 @@ package org.ow2.proactive_grid_cloud_portal.rm.client;
 
 import java.util.Arrays;
 
-import javax.ws.rs.NotFoundException;
-
 
 /**
  * Indicate the status of a node source.

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
@@ -48,6 +48,7 @@ import org.ow2.proactive_grid_cloud_portal.rm.shared.CatalogKind;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.RMConfig;
 
 import com.google.gwt.core.client.Callback;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.json.client.*;
@@ -1935,6 +1936,10 @@ public class RMController extends Controller implements UncaughtExceptionHandler
                                      syncCallBack.onSuccess(parseAllScriptResults(result));
                                  }
                              });
+    }
+
+    public String getAbsoluteUrlFromRelativePath(String path) {
+        return GWT.getHostPageBaseURL().replace("/rm", "") + path;
     }
 
     private void reportScriptExecutionFailure(Throwable caught, String script, String scriptTarget,

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMController.java
@@ -48,7 +48,6 @@ import org.ow2.proactive_grid_cloud_portal.rm.shared.CatalogKind;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.RMConfig;
 
 import com.google.gwt.core.client.Callback;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.json.client.*;
@@ -1939,7 +1938,7 @@ public class RMController extends Controller implements UncaughtExceptionHandler
     }
 
     public String getAbsoluteUrlFromRelativePath(String path) {
-        return GWT.getHostPageBaseURL().replace("/rm", "") + path;
+        return RMConfig.get().getAbsoluteUrlWithPath(path);
     }
 
     private void reportScriptExecutionFailure(Throwable caught, String script, String scriptTarget,

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -37,7 +37,6 @@ import org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.EditDyna
 import org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.EditNodeSourceWindow;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.RMConfig;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -171,7 +170,7 @@ public class RMPage implements LogListener {
         rl.setHeight100();
         rl.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
 
-        this.aboutWindow = new AboutWindow(GWT.getHostPageBaseURL().replace("/rm/", "/rest/"));
+        this.aboutWindow = new AboutWindow(RMConfig.get().getRestPublicUrlOrGuessRestUrl());
         this.addNodeWindow = new AddNodeWindow();
         this.settingsWindow = new SettingsWindow(controller);
         this.loggersWindow = new LoggersWindow(controller);
@@ -415,7 +414,7 @@ public class RMPage implements LogListener {
 
         MenuItem documentationMenuItem = new MenuItem("Documentation",
                                                       Images.instance.icon_manual().getSafeUri().asString());
-        documentationMenuItem.addClickHandler(event -> Window.open(controller.getAbsoluteUrlFromRelativePath("doc/"),
+        documentationMenuItem.addClickHandler(event -> Window.open(controller.getAbsoluteUrlFromRelativePath("/doc/"),
                                                                    "Documentation",
                                                                    ""));
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMPage.java
@@ -37,6 +37,7 @@ import org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.EditDyna
 import org.ow2.proactive_grid_cloud_portal.rm.client.nodesource.edition.EditNodeSourceWindow;
 import org.ow2.proactive_grid_cloud_portal.rm.shared.RMConfig;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -170,7 +171,7 @@ public class RMPage implements LogListener {
         rl.setHeight100();
         rl.setBackgroundColor(LOGO_STRIP_BACKGROUND_COLOR);
 
-        this.aboutWindow = new AboutWindow();
+        this.aboutWindow = new AboutWindow(GWT.getHostPageBaseURL().replace("/rm/", "/rest/"));
         this.addNodeWindow = new AddNodeWindow();
         this.settingsWindow = new SettingsWindow(controller);
         this.loggersWindow = new LoggersWindow(controller);
@@ -414,7 +415,9 @@ public class RMPage implements LogListener {
 
         MenuItem documentationMenuItem = new MenuItem("Documentation",
                                                       Images.instance.icon_manual().getSafeUri().asString());
-        documentationMenuItem.addClickHandler(event -> Window.open("/doc/", "Documentation", ""));
+        documentationMenuItem.addClickHandler(event -> Window.open(controller.getAbsoluteUrlFromRelativePath("doc/"),
+                                                                   "Documentation",
+                                                                   ""));
 
         MenuItem aboutMenuItem = new MenuItem("About", Images.instance.about_16().getSafeUri().asString());
         aboutMenuItem.addClickHandler(event -> RMPage.this.aboutWindow.show());
@@ -634,5 +637,4 @@ public class RMPage implements LogListener {
         RMPage.this.logWindow.show();
         errorButton.hide();
     }
-
 }

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMService.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMService.java
@@ -32,8 +32,6 @@ import java.util.Set;
 import org.ow2.proactive_grid_cloud_portal.common.shared.RestServerException;
 import org.ow2.proactive_grid_cloud_portal.common.shared.ServiceException;
 
-import com.google.gwt.http.client.Request;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeanChart.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeanChart.java
@@ -75,10 +75,6 @@ import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.smartgwt.client.widgets.Label;
-import com.smartgwt.client.widgets.form.DynamicForm;
-import com.smartgwt.client.widgets.form.fields.SelectItem;
-import com.smartgwt.client.widgets.form.fields.events.ChangedEvent;
-import com.smartgwt.client.widgets.form.fields.events.ChangedHandler;
 import com.smartgwt.client.widgets.layout.VLayout;
 
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeanDetailedView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeanDetailedView.java
@@ -31,7 +31,6 @@ import org.ow2.proactive_grid_cloud_portal.common.client.json.JSONUtils;
 import org.ow2.proactive_grid_cloud_portal.common.client.model.LogModel;
 import org.ow2.proactive_grid_cloud_portal.common.client.model.LoginModel;
 import org.ow2.proactive_grid_cloud_portal.rm.client.RMController;
-import org.ow2.proactive_grid_cloud_portal.rm.client.RMModel;
 import org.ow2.proactive_grid_cloud_portal.rm.client.RMServiceAsync;
 
 import com.google.gwt.json.client.JSONArray;

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeansChart.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/charts/MBeansChart.java
@@ -32,7 +32,6 @@ import org.ow2.proactive_grid_cloud_portal.common.client.json.JSONUtils;
 import org.ow2.proactive_grid_cloud_portal.common.client.model.LogModel;
 import org.ow2.proactive_grid_cloud_portal.common.client.model.LoginModel;
 import org.ow2.proactive_grid_cloud_portal.rm.client.RMController;
-import org.ow2.proactive_grid_cloud_portal.rm.client.RMModel;
 import org.ow2.proactive_grid_cloud_portal.rm.client.RMServiceAsync;
 
 import com.google.gwt.json.client.JSONArray;

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactFlowPanel.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactFlowPanel.java
@@ -25,7 +25,6 @@
  */
 package org.ow2.proactive_grid_cloud_portal.rm.client.monitoring.views.compact;
 
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/NodeRemover.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/NodeRemover.java
@@ -25,8 +25,8 @@
  */
 package org.ow2.proactive_grid_cloud_portal.rm.client.monitoring.views.compact;
 
-import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.*;
-import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host.*;
+import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host;
+import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host.Node;
 
 import java.util.Iterator;
 import java.util.Optional;

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/Tile.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/Tile.java
@@ -25,8 +25,8 @@
  */
 package org.ow2.proactive_grid_cloud_portal.rm.client.monitoring.views.compact;
 
-import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.*;
-import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host.*;
+import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host;
+import static org.ow2.proactive_grid_cloud_portal.rm.client.NodeSource.Host.Node;
 
 import java.util.Optional;
 

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/RMConfig.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/shared/RMConfig.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 
 import org.ow2.proactive_grid_cloud_portal.common.shared.Config;
 
+import com.google.gwt.core.client.GWT;
+
 
 /**
  * RM specific configuration
@@ -171,10 +173,15 @@ public class RMConfig extends Config {
     }
 
     @Override
+    public String getAbsoluteUrlWithPath(String path) {
+        return GWT.getHostPageBaseURL().replace("/rm/", path);
+    }
+
+    @Override
     protected String getRestPublicUrlIfDefinedOrOverridden() {
         String restPublicUrl = properties.get(REST_PUBLIC_URL);
-        if ((restPublicUrl == null || restPublicUrl.isEmpty()) && !getRestUrl().equals(DEFAULT_REST_URL)) {
-            return getRestUrl();
+        if (restPublicUrl == null) {
+            return GWT.getHostPageBaseURL().replace("/rm/", "/rest");
         }
         return restPublicUrl;
     }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/ManageLabelsWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/ManageLabelsWindow.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.ow2.proactive_grid_cloud_portal.common.client.Images;
-import org.ow2.proactive_grid_cloud_portal.common.client.model.LogModel;
 
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.ListGridFieldType;

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/PlanWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/PlanWindow.java
@@ -25,23 +25,11 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.client;
 
-import org.ow2.proactive_grid_cloud_portal.common.client.Images;
-
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.FormPanel;
-import com.google.gwt.user.client.ui.FormPanel.SubmitCompleteEvent;
-import com.google.gwt.user.client.ui.FormPanel.SubmitCompleteHandler;
-import com.google.gwt.user.client.ui.InlineLabel;
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.widgets.IButton;
 import com.smartgwt.client.widgets.Label;
 import com.smartgwt.client.widgets.Window;
-import com.smartgwt.client.widgets.events.ClickEvent;
-import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.layout.HLayout;
-import com.smartgwt.client.widgets.layout.Layout;
 import com.smartgwt.client.widgets.layout.VLayout;
 
 
@@ -125,7 +113,8 @@ public class PlanWindow {
 
         yesButton = new IButton("Yes");
         yesButton.addClickHandler(clickEvent -> {
-            com.google.gwt.user.client.Window.open(JPP_URL, JPP_URL, "");
+            String path = controller.getAbsoluteUrlFromRelativePath(JPP_URL);
+            com.google.gwt.user.client.Window.open(path, path, "");
             PlanWindow.this.window.hide();
             PlanWindow.this.destroy();
         });

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerController.java
@@ -54,7 +54,6 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.VarInfoView;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerPortalDisplayConfig;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONException;
@@ -1270,6 +1269,6 @@ public class SchedulerController extends Controller implements UncaughtException
     }
 
     public String getAbsoluteUrlFromRelativePath(String path) {
-        return GWT.getHostPageBaseURL().replace("/scheduler/", "") + path;
+        return SchedulerConfig.get().getAbsoluteUrlWithPath(path);
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerController.java
@@ -54,6 +54,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.VarInfoView;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerPortalDisplayConfig;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONException;
@@ -1266,5 +1267,9 @@ public class SchedulerController extends Controller implements UncaughtException
 
     public SchedulerPage getSchedulerPage() {
         return schedulerView;
+    }
+
+    public String getAbsoluteUrlFromRelativePath(String path) {
+        return GWT.getHostPageBaseURL().replace("/scheduler/", "") + path;
     }
 }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
@@ -267,7 +267,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         contentLayout.setHeight100();
         contentLayout.setBackgroundColor(logoStripBackgroundColor);
 
-        this.aboutWindow = new AboutWindow(GWT.getHostPageBaseURL().replace("/scheduler/", "/rest/"));
+        this.aboutWindow = new AboutWindow(SchedulerConfig.get().getRestPublicUrlOrGuessRestUrl());
         this.settingsWindow = new SettingsWindow(controller);
         this.manageLabelsWindow = new ManageLabelsWindow(controller);
         this.accountInfoWindow = new AccountInfoWindow(controller);

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerPage.java
@@ -267,7 +267,7 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
         contentLayout.setHeight100();
         contentLayout.setBackgroundColor(logoStripBackgroundColor);
 
-        this.aboutWindow = new AboutWindow();
+        this.aboutWindow = new AboutWindow(GWT.getHostPageBaseURL().replace("/scheduler/", "/rest/"));
         this.settingsWindow = new SettingsWindow(controller);
         this.manageLabelsWindow = new ManageLabelsWindow(controller);
         this.accountInfoWindow = new AccountInfoWindow(controller);
@@ -488,7 +488,9 @@ public class SchedulerPage implements SchedulerStatusListener, LogListener, Exec
 
         MenuItem documentationMenuItem = new MenuItem("Documentation",
                                                       Images.instance.icon_manual().getSafeUri().asString());
-        documentationMenuItem.addClickHandler(event -> Window.open("/doc/", "Documentation", ""));
+        documentationMenuItem.addClickHandler(event -> Window.open(controller.getAbsoluteUrlFromRelativePath("/doc/"),
+                                                                   "Documentation",
+                                                                   ""));
 
         MenuItem aboutMenuItem = new MenuItem("About", Images.instance.about_16().getSafeUri().asString());
         aboutMenuItem.addClickHandler(event -> SchedulerPage.this.aboutWindow.show());

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SettingsWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SettingsWindow.java
@@ -27,16 +27,12 @@ package org.ow2.proactive_grid_cloud_portal.scheduler.client;
 
 import org.ow2.proactive_grid_cloud_portal.common.client.Images;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.SettingsController;
-import org.ow2.proactive_grid_cloud_portal.scheduler.shared.PaginatedItemType;
-import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
 import com.smartgwt.client.data.DataSource;
 import com.smartgwt.client.data.fields.DataSourceIntegerField;
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.widgets.IButton;
 import com.smartgwt.client.widgets.Window;
-import com.smartgwt.client.widgets.events.ClickEvent;
-import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
 import com.smartgwt.client.widgets.form.validator.IntegerRangeValidator;
 import com.smartgwt.client.widgets.form.validator.IsIntegerValidator;

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -566,11 +566,12 @@ public class SubmitWindow {
                 existBucketName = false;
             }
             if (existDocumentation) {
-                documentation = attribute.getNodeValue();
+                documentation = GWT.getHostPageBaseURL().replace("/scheduler", attribute.getNodeValue());
                 existDocumentation = false;
             }
             if (existIcon) {
-                icon = attribute.getNodeValue();
+                icon = GWT.getHostPageBaseURL().replace("/scheduler/",
+                                                        attribute.getAttributes().getNamedItem("href").getNodeValue());
                 existIcon = false;
             }
         }
@@ -759,7 +760,9 @@ public class SubmitWindow {
         firstPart.getElement().getStyle().setProperty("margin-left", "15px");
         planJobPanel.add(firstPart);
         Anchor jobPlannerPortalLink = new Anchor("Job Planner Portal",
-                                                 "/automation-dashboard/#/portal/job-planner-calendar-def-workflows",
+                                                 GWT.getHostPageBaseURL()
+                                                    .replace("/scheduler/",
+                                                             "/automation-dashboard/#/portal/job-planner-calendar-def-workflows"),
                                                  "_blank");
         planJobPanel.add(jobPlannerPortalLink);
         planJobPanel.add(new InlineLabel(" to schedule the workflow execution periodically"));

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -38,6 +38,7 @@ import org.ow2.proactive_grid_cloud_portal.common.client.model.LoginModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.JobsController;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.JobVariable;
 import org.ow2.proactive_grid_cloud_portal.scheduler.server.SubmitEditServlet;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
 import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
@@ -45,44 +46,16 @@ import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.RequestBuilder;
-import com.google.gwt.http.client.RequestCallback;
-import com.google.gwt.http.client.RequestException;
-import com.google.gwt.http.client.Response;
+import com.google.gwt.http.client.*;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.HasDirection;
-import com.google.gwt.json.client.JSONArray;
-import com.google.gwt.json.client.JSONBoolean;
-import com.google.gwt.json.client.JSONException;
-import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.json.client.JSONParser;
-import com.google.gwt.json.client.JSONString;
-import com.google.gwt.json.client.JSONValue;
+import com.google.gwt.json.client.*;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
-import com.google.gwt.user.client.ui.Anchor;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.FileUpload;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.FormPanel;
+import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FormPanel.SubmitCompleteEvent;
 import com.google.gwt.user.client.ui.FormPanel.SubmitCompleteHandler;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.HasHorizontalAlignment;
-import com.google.gwt.user.client.ui.Hidden;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.InlineLabel;
-import com.google.gwt.user.client.ui.ListBox;
-import com.google.gwt.user.client.ui.RadioButton;
-import com.google.gwt.user.client.ui.VerticalPanel;
-import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.xml.client.Document;
-import com.google.gwt.xml.client.NamedNodeMap;
-import com.google.gwt.xml.client.Node;
-import com.google.gwt.xml.client.NodeList;
-import com.google.gwt.xml.client.XMLParser;
+import com.google.gwt.xml.client.*;
 import com.smartgwt.client.types.Alignment;
 import com.smartgwt.client.types.Overflow;
 import com.smartgwt.client.util.DateUtil;
@@ -93,11 +66,7 @@ import com.smartgwt.client.widgets.Window;
 import com.smartgwt.client.widgets.events.ClickEvent;
 import com.smartgwt.client.widgets.events.ClickHandler;
 import com.smartgwt.client.widgets.form.DynamicForm;
-import com.smartgwt.client.widgets.form.fields.BlurbItem;
-import com.smartgwt.client.widgets.form.fields.FormItem;
-import com.smartgwt.client.widgets.form.fields.TextAreaItem;
-import com.smartgwt.client.widgets.form.fields.TextItem;
-import com.smartgwt.client.widgets.form.fields.TimeItem;
+import com.smartgwt.client.widgets.form.fields.*;
 import com.smartgwt.client.widgets.form.fields.events.ChangedHandler;
 import com.smartgwt.client.widgets.layout.HLayout;
 import com.smartgwt.client.widgets.layout.Layout;
@@ -566,11 +535,11 @@ public class SubmitWindow {
                 existBucketName = false;
             }
             if (existDocumentation) {
-                documentation = GWT.getHostPageBaseURL().replace("/scheduler", "/doc/" + attribute.getNodeValue());
+                documentation = SchedulerConfig.get().getAbsoluteUrlWithPath("/doc/" + attribute.getNodeValue());
                 existDocumentation = false;
             }
             if (existIcon) {
-                icon = GWT.getHostPageBaseURL().replace("/scheduler/", attribute.getNodeValue());
+                icon = SchedulerConfig.get().getAbsoluteUrlWithPath(attribute.getNodeValue());
                 existIcon = false;
             }
         }
@@ -759,9 +728,8 @@ public class SubmitWindow {
         firstPart.getElement().getStyle().setProperty("margin-left", "15px");
         planJobPanel.add(firstPart);
         Anchor jobPlannerPortalLink = new Anchor("Job Planner Portal",
-                                                 GWT.getHostPageBaseURL()
-                                                    .replace("/scheduler/",
-                                                             "/automation-dashboard/#/portal/job-planner-calendar-def-workflows"),
+                                                 SchedulerConfig.get()
+                                                                .getAbsoluteUrlWithPath("/automation-dashboard/#/portal/job-planner-calendar-def-workflows"),
                                                  "_blank");
         planJobPanel.add(jobPlannerPortalLink);
         planJobPanel.add(new InlineLabel(" to schedule the workflow execution periodically"));

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SubmitWindow.java
@@ -514,7 +514,7 @@ public class SubmitWindow {
         }
 
         if (documentation != null) {
-            widgetDocumentation = "<b>Documentation :</b> <a href=/doc/" + documentation + " target=_blank>" +
+            widgetDocumentation = "<b>Documentation :</b> <a href=" + documentation + " target=_blank>" +
                                   documentation + " </a><br>";
         }
 
@@ -566,12 +566,11 @@ public class SubmitWindow {
                 existBucketName = false;
             }
             if (existDocumentation) {
-                documentation = GWT.getHostPageBaseURL().replace("/scheduler", attribute.getNodeValue());
+                documentation = GWT.getHostPageBaseURL().replace("/scheduler", "/doc/" + attribute.getNodeValue());
                 existDocumentation = false;
             }
             if (existIcon) {
-                icon = GWT.getHostPageBaseURL().replace("/scheduler/",
-                                                        attribute.getAttributes().getNamedItem("href").getNodeValue());
+                icon = GWT.getHostPageBaseURL().replace("/scheduler/", attribute.getNodeValue());
                 existIcon = false;
             }
         }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.JobsController;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.JobVisuMap;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.event.dom.client.LoadEvent;
@@ -224,7 +225,9 @@ public class VisualizationViewHtml implements VisualizationView {
         return new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                com.google.gwt.user.client.Window.open(JobsController.STUDIO_URL + job.getId().toString(),
+                com.google.gwt.user.client.Window.open(GWT.getHostPageBaseURL().replace("/scheduler/",
+                                                                                        JobsController.STUDIO_URL +
+                                                                                                       job.getId()),
                                                        "_blank",
                                                        "");
             }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
@@ -159,10 +159,10 @@ public class VisualizationViewHtml implements VisualizationView {
         wrapper.setSize(width, height);
 
         task2Dom = new HashMap<String, Element>();
-        NodeList<Element> elements = htmlPanel.getElement().getElementsByTagName("div");
-        if (elements != null) {
-            for (int i = 0; i < elements.getLength(); i++) {
-                Element elem = elements.getItem(i);
+        NodeList<Element> divElements = htmlPanel.getElement().getElementsByTagName("div");
+        if (divElements != null) {
+            for (int i = 0; i < divElements.getLength(); i++) {
+                Element elem = divElements.getItem(i);
                 if (elem.getClassName().contains("task")) {
                     // task div - finding it's name
                     String taskName = elem.getInnerText();
@@ -171,6 +171,26 @@ public class VisualizationViewHtml implements VisualizationView {
                     taskName = taskName.trim();
                     task2Dom.put(taskName, elem);
                 }
+            }
+        }
+
+        String basePath = GWT.getHostPageBaseURL().replace("/scheduler/", "");
+
+        NodeList<Element> imgElements = htmlPanel.getElement().getElementsByTagName("img");
+        if (imgElements != null) {
+            for (int i = 0; i < imgElements.getLength(); i++) {
+                Element imgElem = imgElements.getItem(i);
+                String relativeUrl = imgElem.getAttribute("src");
+                imgElem.setAttribute("src", basePath + relativeUrl);
+            }
+        }
+
+        NodeList<Element> linkElements = htmlPanel.getElement().getElementsByTagName("link");
+        if (linkElements != null) {
+            for (int i = 0; i < linkElements.getLength(); i++) {
+                Element linkElem = linkElements.getItem(i);
+                String relativeUrl = linkElem.getAttribute("href");
+                linkElem.setAttribute("href", basePath + relativeUrl);
             }
         }
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewHtml.java
@@ -30,8 +30,8 @@ import java.util.List;
 
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.JobsController;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.JobVisuMap;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.event.dom.client.LoadEvent;
@@ -174,7 +174,7 @@ public class VisualizationViewHtml implements VisualizationView {
             }
         }
 
-        String basePath = GWT.getHostPageBaseURL().replace("/scheduler/", "");
+        String basePath = SchedulerConfig.get().getAbsoluteUrlWithPath("");
 
         NodeList<Element> imgElements = htmlPanel.getElement().getElementsByTagName("img");
         if (imgElements != null) {
@@ -245,9 +245,9 @@ public class VisualizationViewHtml implements VisualizationView {
         return new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                com.google.gwt.user.client.Window.open(GWT.getHostPageBaseURL().replace("/scheduler/",
-                                                                                        JobsController.STUDIO_URL +
-                                                                                                       job.getId()),
+                com.google.gwt.user.client.Window.open(SchedulerConfig.get()
+                                                                      .getAbsoluteUrlWithPath(JobsController.STUDIO_URL +
+                                                                                              job.getId()),
                                                        "_blank",
                                                        "");
             }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
@@ -32,9 +32,12 @@ import java.util.Map.Entry;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.JobsModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.JobVisuMap;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.xml.client.Document;
+import com.google.gwt.xml.client.Node;
 import com.hydro4ge.raphaelgwt.client.Raphael;
 import com.hydro4ge.raphaelgwt.client.Raphael.Rect;
 import com.smartgwt.client.types.Alignment;
@@ -279,8 +282,9 @@ public class VisualizationViewImage implements VisualizationView {
         if (!jobsModel.getSelectedJob().getId().toString().equals(jobId))
             return;
 
+        String baseUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "");
         this.imgPath = path;
-        this.imgLoader = new Image("images/" + this.imgPath);
+        this.imgLoader = new Image(baseUrl + "/images/" + this.imgPath);
         this.imgLoader.addLoadHandler(this);
         this.message.setContents("Fetching image...");
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/VisualizationViewImage.java
@@ -31,13 +31,11 @@ import java.util.Map.Entry;
 
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.JobsModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.JobVisuMap;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.RootPanel;
-import com.google.gwt.xml.client.Document;
-import com.google.gwt.xml.client.Node;
 import com.hydro4ge.raphaelgwt.client.Raphael;
 import com.hydro4ge.raphaelgwt.client.Raphael.Rect;
 import com.smartgwt.client.types.Alignment;
@@ -49,14 +47,7 @@ import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.Img;
 import com.smartgwt.client.widgets.Label;
 import com.smartgwt.client.widgets.WidgetCanvas;
-import com.smartgwt.client.widgets.events.ClickEvent;
-import com.smartgwt.client.widgets.events.ClickHandler;
-import com.smartgwt.client.widgets.events.MouseStillDownEvent;
-import com.smartgwt.client.widgets.events.MouseStillDownHandler;
-import com.smartgwt.client.widgets.events.ResizedEvent;
-import com.smartgwt.client.widgets.events.ResizedHandler;
-import com.smartgwt.client.widgets.events.ScrolledEvent;
-import com.smartgwt.client.widgets.events.ScrolledHandler;
+import com.smartgwt.client.widgets.events.*;
 import com.smartgwt.client.widgets.layout.Layout;
 import com.smartgwt.client.widgets.menu.Menu;
 
@@ -282,7 +273,7 @@ public class VisualizationViewImage implements VisualizationView {
         if (!jobsModel.getSelectedJob().getId().toString().equals(jobId))
             return;
 
-        String baseUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "");
+        String baseUrl = SchedulerConfig.get().getAbsoluteUrlWithPath("");
         this.imgPath = path;
         this.imgLoader = new Image(baseUrl + "/images/" + this.imgPath);
         this.imgLoader.addLoadHandler(this);

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsController.java
@@ -44,6 +44,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.JobResultView;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.JobsView;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.KeyValueGrid;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.jobs.JobsListGrid;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;
@@ -529,7 +530,7 @@ public class JobsController {
      * @param jobId id of the job
      */
     public void openStudio(String jobId) {
-        String studioUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "") + STUDIO_URL;
+        String studioUrl = SchedulerConfig.get().getAbsoluteUrlWithPath(STUDIO_URL);
         com.google.gwt.user.client.Window.open(studioUrl + jobId, "_blank", "");
 
     }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsController.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/controller/JobsController.java
@@ -529,8 +529,8 @@ public class JobsController {
      * @param jobId id of the job
      */
     public void openStudio(String jobId) {
-
-        com.google.gwt.user.client.Window.open(STUDIO_URL + jobId, "_blank", "");
+        String studioUrl = GWT.getHostPageBaseURL().replace("/scheduler/", "") + STUDIO_URL;
+        com.google.gwt.user.client.Window.open(studioUrl + jobId, "_blank", "");
 
     }
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsPaginationModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/JobsPaginationModel.java
@@ -25,7 +25,6 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.client.model;
 
-import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerListeners.PaginationListener;
 import org.ow2.proactive_grid_cloud_portal.scheduler.shared.PaginatedItemType;
 
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksCentricModel.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/model/TasksCentricModel.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.Job;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerListeners.JobSelectedListener;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerModelImpl;
-import org.ow2.proactive_grid_cloud_portal.scheduler.client.Task;
 
 
 public class TasksCentricModel extends TasksModel {

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/JobInfoView.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/JobInfoView.java
@@ -37,7 +37,6 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.controller.Execution
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.ExecutionsModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.model.JobsModel;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.ColumnsFactory;
-import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.KeyValueGrid;
 
 import com.smartgwt.client.widgets.layout.Layout;
 import com.smartgwt.client.widgets.layout.VStack;

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/KeyValueColumnsFactory.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/KeyValueColumnsFactory.java
@@ -31,6 +31,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.client.util.JobColumnsUtil;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.ColumnsFactory;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.GridColumns;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Anchor;
 import com.smartgwt.client.data.Record;
 import com.smartgwt.client.util.StringUtil;
@@ -58,7 +59,10 @@ public class KeyValueColumnsFactory implements ColumnsFactory<Map.Entry<String, 
         if (JobColumnsUtil.START_AT.equals(item.getKey()))
             record.setAttribute(VALUE_ATTR.getName(), JobColumnsUtil.getFormattedDateString(item.getValue()));
         else if (JobColumnsUtil.DOCUMENTATION.equals(item.getKey()))
-            record.setAttribute(VALUE_ATTR.getName(), new Anchor(item.getValue(), "/doc/" + item.getValue(), "_blank"));
+            record.setAttribute(VALUE_ATTR.getName(),
+                                new Anchor(item.getValue(),
+                                           GWT.getHostPageBaseURL().replace("/scheduler/", "/doc/" + item.getValue()),
+                                           "_blank"));
         else
             record.setAttribute(VALUE_ATTR.getName(), StringUtil.asHTML(item.getValue()));
     }

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/KeyValueColumnsFactory.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/KeyValueColumnsFactory.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.util.JobColumnsUtil;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.ColumnsFactory;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.view.grid.GridColumns;
+import org.ow2.proactive_grid_cloud_portal.scheduler.shared.SchedulerConfig;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Anchor;
 import com.smartgwt.client.data.Record;
 import com.smartgwt.client.util.StringUtil;
@@ -61,7 +61,7 @@ public class KeyValueColumnsFactory implements ColumnsFactory<Map.Entry<String, 
         else if (JobColumnsUtil.DOCUMENTATION.equals(item.getKey()))
             record.setAttribute(VALUE_ATTR.getName(),
                                 new Anchor(item.getValue(),
-                                           GWT.getHostPageBaseURL().replace("/scheduler/", "/doc/" + item.getValue()),
+                                           SchedulerConfig.get().getAbsoluteUrlWithPath("/doc/" + item.getValue()),
                                            "_blank"));
         else
             record.setAttribute(VALUE_ATTR.getName(), StringUtil.asHTML(item.getValue()));

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/ExportUsageServlet.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/server/ExportUsageServlet.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/JobVisuMap.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/JobVisuMap.java
@@ -25,7 +25,6 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.shared;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -246,6 +246,11 @@ public class SchedulerConfig extends Config {
         return properties.get(MOTD_URL);
     }
 
+    @Override
+    public String getAbsoluteUrlWithPath(String path) {
+        return GWT.getHostPageBaseURL().replace("/scheduler/", path);
+    }
+
     /**
      * @return the client refresh rate in millis
      */

--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/shared/SchedulerConfig.java
@@ -27,6 +27,8 @@ package org.ow2.proactive_grid_cloud_portal.scheduler.shared;
 
 import org.ow2.proactive_grid_cloud_portal.common.shared.Config;
 
+import com.google.gwt.core.client.GWT;
+
 
 /**
  * Scheduler specific configuration
@@ -190,9 +192,7 @@ public class SchedulerConfig extends Config {
     public String getRestPublicUrlIfDefinedOrOverridden() {
         String restPublicUrl = properties.get(REST_PUBLIC_URL);
         if (restPublicUrl == null) {
-            String restUrlFromCurrentLocation = getWindowsLocationUrl();
-            restUrlFromCurrentLocation += "/rest";
-            return restUrlFromCurrentLocation;
+            return GWT.getHostPageBaseURL().replace("/scheduler/", "/rest");
         }
         return restPublicUrl;
     }


### PR DESCRIPTION
Fix incorrect portal buttons URLs in RM & Scheduler portal when running behind a reverse proxy by constructing absolute URLs based on the base URL of the application instead of using relative paths