### PR TITLE
Fix Number of nodes by considering also current nodes and not only de…

### DIFF
--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/TreeView.java
@@ -188,7 +188,7 @@ public class TreeView implements NodesListener, NodeSelectedListener {
                                          .flatMap(host -> host.getNodes().values().stream())
                                          .collect(Collectors.toList());
 
-            // Process currentNodes, needed for a dynamic update a NS. Nodes don't change so they are not part of the delta
+            // Process currentNodes, needed for a dynamic update of a NS where nodes haven't changed. Nodes don't change so they are not part of the delta
             nodes.addAll(currentNodes.stream()
                                      .filter(node -> node.getSourceName().equals(nodeSource.getSourceName()) &&
                                                      !nodes.contains(node))

--- a/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
+++ b/rm-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/monitoring/views/compact/CompactView.java
@@ -351,6 +351,9 @@ public class CompactView implements NodesListener, NodeSelectedListener {
                 flow.remove(emptyNs);
             }
             nodeSourceTiles.remove(nodeSource);
+            if (controller.getModel().getNodeSources().isEmpty()) {
+                compactPanel.resetIndex();
+            }
         }
     }
 


### PR DESCRIPTION
…ltas

Fixes after a Dynamic Update:
- The #Nodes column in the tree view
- The Hosts and Nodes rows in the bottom left view
- The Node State graph

Also fixes a bug that appears when you remove all Node Sources until there are none, and then you deploy a new one.
The Hosts and Nodes will never appear in the views (treeview, graphs ...) and the rm portal autorefresh is broken. 
An IndexOutOfBoundsException was thrown because the index in the treeview was not reset when we reached 0 NS.