### PR TITLE
Fix Edit label menu item is enabled even fo unauthorized users:

### DIFF
--- a/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
+++ b/scheduler-portal/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/view/grid/jobs/JobsListGrid.java
@@ -544,9 +544,9 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
                            removeLabels);
 
         controller.getJobSignals(ids.get(0), this);
-        controller.checkJobsPermissionMethods(ids, this);
         controller.getJobLabels(this, ids);
         checkIfLabelsAreEmpty(menu, jobLabels);
+        controller.checkJobsPermissionMethods(ids, this);
     }
 
     private void createPriorityMenu(List<String> ids) {
@@ -631,7 +631,9 @@ public class JobsListGrid extends ItemsListGrid<Job> implements JobsUpdatedListe
             }
         }
         editLabels.setSubmenu(labelsMenu);
-        editLabels.setEnabled(!labels.isEmpty());
+        if (labels.isEmpty()) {
+            editLabels.setEnabled(false);
+        }
         menu.redraw();
     }
 


### PR DESCRIPTION
- Set edit label menu item as disabled if back-end response is empty only. Do not set is as enabled if it contains element as this is done in an async call and will overwrite the permission check.
- Check permission as last operation. It has the final word on enabling or disabling menu items.